### PR TITLE
fix unicode error that prevents install on Windows Server

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ warn_unused_ignores = true
 
 [pydocstyle]
 # D213 - Multi-line docstring summary should start at the second line
-# D402 - First line should not be the function’s “signature”
+# D402 - First line should not be the signature of the function
 add_select = D213, D402
 # D200 - One-line docstring should fit on one line with quotes
 # D205 - 1 blank line required between summary line and description


### PR DESCRIPTION
Remove three characters that threw a UniCodeError when trying to install openscm-runner on a windows server.