### PR TITLE
Fix bandit

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         black --check src tests setup.py --exclude openscm_runner/_version.py
         isort --check-only --quiet --recursive src tests setup.py
         pydocstyle src
-        bandit -c .bandit.yml -r openscm_runner
+        bandit -c .bandit.yml -r src
         flake8 src tests setup.py
         pylint src
     - name: Build docs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,11 @@ Added
 
 - (`#17 <https://github.com/openscm/openscm-runner/pull/17>`_) Support for scmdata >= 0.7.1
 
+Fixed
+~~~~~
+
+- (`#20 <https://github.com/openscm/openscm-runner/pull/20>`_) Update bandit configuration
+
 v0.3.1 - 2020-09-03
 -------------------
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -5,7 +5,7 @@ import logging
 import multiprocessing
 import os.path
 from concurrent.futures import ProcessPoolExecutor
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError  # nosec
 
 import f90nml
 import scmdata

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -3,7 +3,7 @@ MAGICC7 adapter
 """
 import logging
 import os
-from subprocess import check_output
+from subprocess import check_output  # nosec
 
 import pymagicc
 from scmdata import ScmRun
@@ -135,10 +135,13 @@ class MAGICC7(_Adapter):
 
             full_cfgs += scenario_cfg
 
-        assert len(full_cfgs) == scenarios.meta[
-            ["scenario", "model"]
-        ].drop_duplicates().shape[0] * len(cfgs)
-
+        exp_shape = scenarios.meta[["scenario", "model"]].drop_duplicates().shape[
+            0
+        ] * len(cfgs)
+        if len(full_cfgs) != exp_shape:
+            raise AssertionError(
+                "Expected {} configs got {}".format(exp_shape, len(full_cfgs))
+            )
         return full_cfgs
 
     @classmethod

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -75,9 +75,12 @@ def run(
 
         model_meta = set(model_res.meta.columns.tolist())
         climate_model = model_res.get_unique_meta("climate_model")
-        assert model_meta == key_meta, "{} meta: {}, expected meta: {}".format(
-            climate_model, model_meta, key_meta
-        )
+        if model_meta != key_meta:
+            raise AssertionError(
+                "{} meta: {}, expected meta: {}".format(
+                    climate_model, model_meta, key_meta
+                )
+            )
 
     if len(res) == 1:
         LOGGER.info("Only one model run, returning its results")

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -20,7 +20,7 @@ def run(
     scenarios,
     output_variables=("Surface Temperature",),
     full_config=False,
-):
+):  # pylint: disable=W9006
     """
     Run a number of climate models over a number of scenarios
 
@@ -75,7 +75,7 @@ def run(
 
         model_meta = set(model_res.meta.columns.tolist())
         climate_model = model_res.get_unique_meta("climate_model")
-        if model_meta != key_meta:
+        if model_meta != key_meta:  # noqa
             raise AssertionError(
                 "{} meta: {}, expected meta: {}".format(
                     climate_model, model_meta, key_meta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,5 +27,5 @@ def magicc7_is_available():
     try:
         MAGICC7.get_version()
 
-    except KeyError:
+    except ValueError:
         pytest.skip("MAGICC7 not available")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,5 +27,5 @@ def magicc7_is_available():
     try:
         MAGICC7.get_version()
 
-    except ValueError:
+    except KeyError:
         pytest.skip("MAGICC7 not available")


### PR DESCRIPTION
Bandit was not being run. This turns is back on and fixes some failures

We are effectively ignoring the subprocess usage (which arguably is one of the main reasons why bandit should be used). One day I should review the usage of subprocess here and in pymagicc. One day...

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
