### PR TITLE
add csv files to MANIFEST and setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ The changes listed in this file are categorised as follows:
 master
 ------
 
+Fixed
+~~~~~
+
+- (`#26 <https://github.com/openscm/openscm-runner/pull/26>`_) Include csv files needed for running FaIR 1.6 with CMIP6 setup
+
 v0.4.2 - 2020-10-13
 -------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include src/openscm_runner/_version.py
+include src/openscm_runner/adapters/fair_adapter/*.csv

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     keywords=["openscm", "runner", "python", "repo", "simple", "climate", "model"],
     packages=find_packages(SOURCE_DIR),  # no exclude as only searching in `src`
     package_dir={"": SOURCE_DIR},
-    # include_package_data=True,
+    include_package_data=True,
     install_requires=REQUIREMENTS,
     extras_require=REQUIREMENTS_EXTRAS,
     cmdclass=cmdclass,


### PR DESCRIPTION
This fix is needed to include csv files on install for running `openscm-runner`.

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
