### PR TITLE
fix anthropogenic total ERF

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changed
 Fixed
 ~~~~~
 
+- (`#40 <https://github.com/openscm/openscm-runner/pull/40>`_) Report correct index from FaIR as the anthropogenic total ERF 
 - (`#39 <https://github.com/openscm/openscm-runner/pull/39>`_) Include parameter name in the warning message emitted when MAGICC's output config doesn't match the input config specified via OpenSCM-Runner
 - (`#36 <https://github.com/openscm/openscm-runner/pull/36>`_) Hotfix CI after pandas 1.1.5 broke pylint
 - (`#37 <https://github.com/openscm/openscm-runner/pull/33>`_) Ensure FaIR ignores emissions input in scenarios not handled by FaIR, e.g. total CO2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ AUTHORS = [
     ("Robert Gieseke", "robert.gieseke@pik-potsdam.de"),
     ("Jared Lewis", "jared.lewis@climate-energy-college.org"),
     ("Sven Willner", "sven.willner@pik-potsdam.de"),
-    ("Chris Smith", "c.j.smith1@leeds.ac.uk")
+    ("Chris Smith", "c.j.smith1@leeds.ac.uk"),
 ]
 URL = "https://github.com/openscm/openscm-runner"
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ AUTHORS = [
     ("Robert Gieseke", "robert.gieseke@pik-potsdam.de"),
     ("Jared Lewis", "jared.lewis@climate-energy-college.org"),
     ("Sven Willner", "sven.willner@pik-potsdam.de"),
+    ("Chris Smith", "c.j.smith1@leeds.ac.uk")
 ]
 URL = "https://github.com/openscm/openscm-runner"
 

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -215,9 +215,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
         forcing[:, :31], axis=1
     )
     # This definition does not include ozone and H2O from CH4 oxidation
-    data["Effective Radiative Forcing|Kyoto Gases"] = np.sum(
-        forcing[:, :15], axis=1
-    )
+    data["Effective Radiative Forcing|Kyoto Gases"] = np.sum(forcing[:, :15], axis=1)
     data["Effective Radiative Forcing|CO2, CH4 and N2O"] = np.sum(
         forcing[:, :3], axis=1
     )

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -221,6 +221,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
     data["Effective Radiative Forcing|CO2, CH4 and N2O"] = np.sum(
         forcing[:, :3], axis=1
     )
+    # What is the rigorous definition here? CFCs are not included but contain F
     data["Effective Radiative Forcing|F-Gases"] = np.sum(forcing[:, 3:15], axis=1)
     data["Effective Radiative Forcing|Montreal Protocol Halogen Gases"] = np.sum(
         forcing[:, 15:31], axis=1

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -210,7 +210,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
     data["Effective Radiative Forcing|Volcanic"] = forcing[:, 43]
     data["Effective Radiative Forcing|Solar"] = forcing[:, 44]
     data["Effective Radiative Forcing"] = np.sum(forcing, axis=1)
-    data["Effective Radiative Forcing|Anthropogenic"] = np.sum(forcing[:, :39], axis=1)
+    data["Effective Radiative Forcing|Anthropogenic"] = np.sum(forcing[:, :43], axis=1)
     data["Effective Radiative Forcing|Greenhouse Gases"] = np.sum(
         forcing[:, :31], axis=1
     )

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -215,7 +215,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
         forcing[:, :31], axis=1
     )
     # This definition does not include ozone and H2O from CH4 oxidation
-    data["Effective Radiative Forcing|Greenhouse Gases|Kyoto Gases"] = np.sum(
+    data["Effective Radiative Forcing|Kyoto Gases"] = np.sum(
         forcing[:, :15], axis=1
     )
     data["Effective Radiative Forcing|CO2, CH4 and N2O"] = np.sum(
@@ -229,6 +229,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
         forcing[:, 35:40], axis=1
     )
     data["Effective Radiative Forcing|Aerosols"] = np.sum(forcing[:, 35:41], axis=1)
+    data["Effective Radiative Forcing|Ozone"] = np.sum(forcing[:, 31:33], axis=1)
     data["Surface Air Temperature Change"] = temperature
     data["Surface Air Ocean Blended Temperature Change"] = temperature * factors["gmst"]
     data["Airborne Fraction"] = airborne_emissions
@@ -326,6 +327,7 @@ def _process_output(fair_output, output_vars, factors):  # pylint: disable=R0915
     unit["Effective Radiative Forcing|Montreal Protocol Halogen Gases"] = "W/m**2"
     unit["Effective Radiative Forcing|Aerosols|Direct Effect"] = "W/m**2"
     unit["Effective Radiative Forcing|Aerosols"] = "W/m**2"
+    unit["Effective Radiative Forcing|Ozone"] = "W/m**2"
     unit["Surface Air Temperature Change"] = "K"
     unit["Surface Air Ocean Blended Temperature Change"] = "K"
     unit["Airborne Fraction"] = "dimensionless"

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -335,7 +335,7 @@ def test_forcing_categories(test_scenarios):
     ]
 
     res = run(
-        climate_models_cfgs={"FaIR": [{},],},
+        climate_models_cfgs={"FaIR": [{}, ], },
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -273,72 +273,69 @@ def test_startyear(test_scenarios, test_scenarios_2600):
             out_config=None,
         )
 
+
 def test_forcing_categories(test_scenarios):
     forcing_categories = [
-            "Effective Radiative Forcing|CO2",
-            "Effective Radiative Forcing|CH4",
-            "Effective Radiative Forcing|N2O",
-            "Effective Radiative Forcing|CF4",
-            "Effective Radiative Forcing|C2F6",
-            "Effective Radiative Forcing|C6F14",
-            "Effective Radiative Forcing|HFC23",
-            "Effective Radiative Forcing|HFC32",
-            "Effective Radiative Forcing|HFC125",
-            "Effective Radiative Forcing|HFC134a",
-            "Effective Radiative Forcing|HFC143a",
-            "Effective Radiative Forcing|HFC227ea",
-            "Effective Radiative Forcing|HFC245fa",
-            "Effective Radiative Forcing|HFC4310mee",
-            "Effective Radiative Forcing|SF6",
-            "Effective Radiative Forcing|CFC11",
-            "Effective Radiative Forcing|CFC12",
-            "Effective Radiative Forcing|CFC113",
-            "Effective Radiative Forcing|CFC114",
-            "Effective Radiative Forcing|CFC115",
-            "Effective Radiative Forcing|CCl4",
-            "Effective Radiative Forcing|CH3CCl3",
-            "Effective Radiative Forcing|HCFC22",
-            "Effective Radiative Forcing|HCFC141b",
-            "Effective Radiative Forcing|HCFC142b",
-            "Effective Radiative Forcing|Halon1211",
-            "Effective Radiative Forcing|Halon1202",
-            "Effective Radiative Forcing|Halon1301",
-            "Effective Radiative Forcing|Halon2402",
-            "Effective Radiative Forcing|CH3Br",
-            "Effective Radiative Forcing|CH3Cl",
-            "Effective Radiative Forcing|Tropospheric Ozone",
-            "Effective Radiative Forcing|Stratospheric Ozone",
-            "Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O",
-            "Effective Radiative Forcing|Contrails",
-            "Effective Radiative Forcing|Aerosols|Direct Effect|SOx",
-            "Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol",
-            "Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate",
-            "Effective Radiative Forcing|Aerosols|Direct Effect|BC",
-            "Effective Radiative Forcing|Aerosols|Direct Effect|OC",
-            "Effective Radiative Forcing|Aerosols|Indirect Effect",
-            "Effective Radiative Forcing|Black Carbon on Snow",
-            "Effective Radiative Forcing|Land-use Change",
-            "Effective Radiative Forcing|Volcanic",
-            "Effective Radiative Forcing|Solar",
-            "Effective Radiative Forcing",
-            "Effective Radiative Forcing|Anthropogenic",
-            "Effective Radiative Forcing|Greenhouse Gases",
-            "Effective Radiative Forcing|Kyoto Gases",
-            "Effective Radiative Forcing|CO2, CH4 and N2O",
-            "Effective Radiative Forcing|F-Gases",
-            "Effective Radiative Forcing|Montreal Protocol Halogen Gases",
-            "Effective Radiative Forcing|Aerosols|Direct Effect",
-            "Effective Radiative Forcing|Aerosols",
-            "Effective Radiative Forcing|Ozone",
-            "Effective Radiative Forcing",
-        ]
+        "Effective Radiative Forcing|CO2",
+        "Effective Radiative Forcing|CH4",
+        "Effective Radiative Forcing|N2O",
+        "Effective Radiative Forcing|CF4",
+        "Effective Radiative Forcing|C2F6",
+        "Effective Radiative Forcing|C6F14",
+        "Effective Radiative Forcing|HFC23",
+        "Effective Radiative Forcing|HFC32",
+        "Effective Radiative Forcing|HFC125",
+        "Effective Radiative Forcing|HFC134a",
+        "Effective Radiative Forcing|HFC143a",
+        "Effective Radiative Forcing|HFC227ea",
+        "Effective Radiative Forcing|HFC245fa",
+        "Effective Radiative Forcing|HFC4310mee",
+        "Effective Radiative Forcing|SF6",
+        "Effective Radiative Forcing|CFC11",
+        "Effective Radiative Forcing|CFC12",
+        "Effective Radiative Forcing|CFC113",
+        "Effective Radiative Forcing|CFC114",
+        "Effective Radiative Forcing|CFC115",
+        "Effective Radiative Forcing|CCl4",
+        "Effective Radiative Forcing|CH3CCl3",
+        "Effective Radiative Forcing|HCFC22",
+        "Effective Radiative Forcing|HCFC141b",
+        "Effective Radiative Forcing|HCFC142b",
+        "Effective Radiative Forcing|Halon1211",
+        "Effective Radiative Forcing|Halon1202",
+        "Effective Radiative Forcing|Halon1301",
+        "Effective Radiative Forcing|Halon2402",
+        "Effective Radiative Forcing|CH3Br",
+        "Effective Radiative Forcing|CH3Cl",
+        "Effective Radiative Forcing|Tropospheric Ozone",
+        "Effective Radiative Forcing|Stratospheric Ozone",
+        "Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O",
+        "Effective Radiative Forcing|Contrails",
+        "Effective Radiative Forcing|Aerosols|Direct Effect|SOx",
+        "Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol",
+        "Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate",
+        "Effective Radiative Forcing|Aerosols|Direct Effect|BC",
+        "Effective Radiative Forcing|Aerosols|Direct Effect|OC",
+        "Effective Radiative Forcing|Aerosols|Indirect Effect",
+        "Effective Radiative Forcing|Black Carbon on Snow",
+        "Effective Radiative Forcing|Land-use Change",
+        "Effective Radiative Forcing|Volcanic",
+        "Effective Radiative Forcing|Solar",
+        "Effective Radiative Forcing",
+        "Effective Radiative Forcing|Anthropogenic",
+        "Effective Radiative Forcing|Greenhouse Gases",
+        "Effective Radiative Forcing|Kyoto Gases",
+        "Effective Radiative Forcing|CO2, CH4 and N2O",
+        "Effective Radiative Forcing|F-Gases",
+        "Effective Radiative Forcing|Montreal Protocol Halogen Gases",
+        "Effective Radiative Forcing|Aerosols|Direct Effect",
+        "Effective Radiative Forcing|Aerosols",
+        "Effective Radiative Forcing|Ozone",
+        "Effective Radiative Forcing",
+    ]
 
     res = run(
-        climate_models_cfgs={
-            "FaIR": [
-                {},
-            ],
-        },
+        climate_models_cfgs={"FaIR": [{},],},
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,
@@ -347,144 +344,145 @@ def test_forcing_categories(test_scenarios):
     # storing results in a dict makes this a bit more compact
     forcing = {}
     for variable in forcing_categories:
-        forcing[variable] = res.filter(
-            variable=variable,
-            region="World"
-        ).values
+        forcing[variable] = res.filter(variable=variable, region="World").values
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|CO2"] +
-        forcing["Effective Radiative Forcing|CH4"] +
-        forcing["Effective Radiative Forcing|N2O"] +
-        forcing["Effective Radiative Forcing|CF4"] +
-        forcing["Effective Radiative Forcing|C2F6"] +
-        forcing["Effective Radiative Forcing|C6F14"] +
-        forcing["Effective Radiative Forcing|HFC23"] +
-        forcing["Effective Radiative Forcing|HFC32"] +
-        forcing["Effective Radiative Forcing|HFC125"] +
-        forcing["Effective Radiative Forcing|HFC134a"] +
-        forcing["Effective Radiative Forcing|HFC143a"] +
-        forcing["Effective Radiative Forcing|HFC227ea"] +
-        forcing["Effective Radiative Forcing|HFC245fa"] +
-        forcing["Effective Radiative Forcing|HFC4310mee"] +
-        forcing["Effective Radiative Forcing|SF6"] +
-        forcing["Effective Radiative Forcing|CFC11"] +
-        forcing["Effective Radiative Forcing|CFC12"] +
-        forcing["Effective Radiative Forcing|CFC113"] +
-        forcing["Effective Radiative Forcing|CFC114"] +
-        forcing["Effective Radiative Forcing|CFC115"] +
-        forcing["Effective Radiative Forcing|CCl4"] +
-        forcing["Effective Radiative Forcing|CH3CCl3"] +
-        forcing["Effective Radiative Forcing|HCFC22"] +
-        forcing["Effective Radiative Forcing|HCFC141b"] +
-        forcing["Effective Radiative Forcing|HCFC142b"] +
-        forcing["Effective Radiative Forcing|Halon1211"] +
-        forcing["Effective Radiative Forcing|Halon1202"] +
-        forcing["Effective Radiative Forcing|Halon1301"] +
-        forcing["Effective Radiative Forcing|Halon2402"] +
-        forcing["Effective Radiative Forcing|CH3Br"] +
-        forcing["Effective Radiative Forcing|CH3Cl"],
-        forcing["Effective Radiative Forcing|Greenhouse Gases"]  # should this be "well mixed" greenhouse gases?
+        forcing["Effective Radiative Forcing|CO2"]
+        + forcing["Effective Radiative Forcing|CH4"]
+        + forcing["Effective Radiative Forcing|N2O"]
+        + forcing["Effective Radiative Forcing|CF4"]
+        + forcing["Effective Radiative Forcing|C2F6"]
+        + forcing["Effective Radiative Forcing|C6F14"]
+        + forcing["Effective Radiative Forcing|HFC23"]
+        + forcing["Effective Radiative Forcing|HFC32"]
+        + forcing["Effective Radiative Forcing|HFC125"]
+        + forcing["Effective Radiative Forcing|HFC134a"]
+        + forcing["Effective Radiative Forcing|HFC143a"]
+        + forcing["Effective Radiative Forcing|HFC227ea"]
+        + forcing["Effective Radiative Forcing|HFC245fa"]
+        + forcing["Effective Radiative Forcing|HFC4310mee"]
+        + forcing["Effective Radiative Forcing|SF6"]
+        + forcing["Effective Radiative Forcing|CFC11"]
+        + forcing["Effective Radiative Forcing|CFC12"]
+        + forcing["Effective Radiative Forcing|CFC113"]
+        + forcing["Effective Radiative Forcing|CFC114"]
+        + forcing["Effective Radiative Forcing|CFC115"]
+        + forcing["Effective Radiative Forcing|CCl4"]
+        + forcing["Effective Radiative Forcing|CH3CCl3"]
+        + forcing["Effective Radiative Forcing|HCFC22"]
+        + forcing["Effective Radiative Forcing|HCFC141b"]
+        + forcing["Effective Radiative Forcing|HCFC142b"]
+        + forcing["Effective Radiative Forcing|Halon1211"]
+        + forcing["Effective Radiative Forcing|Halon1202"]
+        + forcing["Effective Radiative Forcing|Halon1301"]
+        + forcing["Effective Radiative Forcing|Halon2402"]
+        + forcing["Effective Radiative Forcing|CH3Br"]
+        + forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing[
+            "Effective Radiative Forcing|Greenhouse Gases"
+        ],  # should this be "well mixed" greenhouse gases?
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|CO2"] +
-        forcing["Effective Radiative Forcing|CH4"] +
-        forcing["Effective Radiative Forcing|N2O"] +
-        forcing["Effective Radiative Forcing|CF4"] +
-        forcing["Effective Radiative Forcing|C2F6"] +
-        forcing["Effective Radiative Forcing|C6F14"] +
-        forcing["Effective Radiative Forcing|HFC23"] +
-        forcing["Effective Radiative Forcing|HFC32"] +
-        forcing["Effective Radiative Forcing|HFC125"] +
-        forcing["Effective Radiative Forcing|HFC134a"] +
-        forcing["Effective Radiative Forcing|HFC143a"] +
-        forcing["Effective Radiative Forcing|HFC227ea"] +
-        forcing["Effective Radiative Forcing|HFC245fa"] +
-        forcing["Effective Radiative Forcing|HFC4310mee"] +
-        forcing["Effective Radiative Forcing|SF6"],
-        forcing["Effective Radiative Forcing|Kyoto Gases"]
+        forcing["Effective Radiative Forcing|CO2"]
+        + forcing["Effective Radiative Forcing|CH4"]
+        + forcing["Effective Radiative Forcing|N2O"]
+        + forcing["Effective Radiative Forcing|CF4"]
+        + forcing["Effective Radiative Forcing|C2F6"]
+        + forcing["Effective Radiative Forcing|C6F14"]
+        + forcing["Effective Radiative Forcing|HFC23"]
+        + forcing["Effective Radiative Forcing|HFC32"]
+        + forcing["Effective Radiative Forcing|HFC125"]
+        + forcing["Effective Radiative Forcing|HFC134a"]
+        + forcing["Effective Radiative Forcing|HFC143a"]
+        + forcing["Effective Radiative Forcing|HFC227ea"]
+        + forcing["Effective Radiative Forcing|HFC245fa"]
+        + forcing["Effective Radiative Forcing|HFC4310mee"]
+        + forcing["Effective Radiative Forcing|SF6"],
+        forcing["Effective Radiative Forcing|Kyoto Gases"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|CO2"] +
-        forcing["Effective Radiative Forcing|CH4"] +
-        forcing["Effective Radiative Forcing|N2O"],
-        forcing["Effective Radiative Forcing|CO2, CH4 and N2O"]
+        forcing["Effective Radiative Forcing|CO2"]
+        + forcing["Effective Radiative Forcing|CH4"]
+        + forcing["Effective Radiative Forcing|N2O"],
+        forcing["Effective Radiative Forcing|CO2, CH4 and N2O"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|CF4"] +
-        forcing["Effective Radiative Forcing|C2F6"] +
-        forcing["Effective Radiative Forcing|C6F14"] +
-        forcing["Effective Radiative Forcing|HFC23"] +
-        forcing["Effective Radiative Forcing|HFC32"] +
-        forcing["Effective Radiative Forcing|HFC125"] +
-        forcing["Effective Radiative Forcing|HFC134a"] +
-        forcing["Effective Radiative Forcing|HFC143a"] +
-        forcing["Effective Radiative Forcing|HFC227ea"] +
-        forcing["Effective Radiative Forcing|HFC245fa"] +
-        forcing["Effective Radiative Forcing|HFC4310mee"] +
-        forcing["Effective Radiative Forcing|SF6"], 
-        forcing["Effective Radiative Forcing|F-Gases"]
+        forcing["Effective Radiative Forcing|CF4"]
+        + forcing["Effective Radiative Forcing|C2F6"]
+        + forcing["Effective Radiative Forcing|C6F14"]
+        + forcing["Effective Radiative Forcing|HFC23"]
+        + forcing["Effective Radiative Forcing|HFC32"]
+        + forcing["Effective Radiative Forcing|HFC125"]
+        + forcing["Effective Radiative Forcing|HFC134a"]
+        + forcing["Effective Radiative Forcing|HFC143a"]
+        + forcing["Effective Radiative Forcing|HFC227ea"]
+        + forcing["Effective Radiative Forcing|HFC245fa"]
+        + forcing["Effective Radiative Forcing|HFC4310mee"]
+        + forcing["Effective Radiative Forcing|SF6"],
+        forcing["Effective Radiative Forcing|F-Gases"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|CFC11"] +
-        forcing["Effective Radiative Forcing|CFC12"] +
-        forcing["Effective Radiative Forcing|CFC113"] +
-        forcing["Effective Radiative Forcing|CFC114"] +
-        forcing["Effective Radiative Forcing|CFC115"] +
-        forcing["Effective Radiative Forcing|CCl4"] +
-        forcing["Effective Radiative Forcing|CH3CCl3"] +
-        forcing["Effective Radiative Forcing|HCFC22"] +
-        forcing["Effective Radiative Forcing|HCFC141b"] +
-        forcing["Effective Radiative Forcing|HCFC142b"] +
-        forcing["Effective Radiative Forcing|Halon1211"] +
-        forcing["Effective Radiative Forcing|Halon1202"] +
-        forcing["Effective Radiative Forcing|Halon1301"] +
-        forcing["Effective Radiative Forcing|Halon2402"] +
-        forcing["Effective Radiative Forcing|CH3Br"] +
-        forcing["Effective Radiative Forcing|CH3Cl"],
-        forcing["Effective Radiative Forcing|Montreal Protocol Halogen Gases"]
+        forcing["Effective Radiative Forcing|CFC11"]
+        + forcing["Effective Radiative Forcing|CFC12"]
+        + forcing["Effective Radiative Forcing|CFC113"]
+        + forcing["Effective Radiative Forcing|CFC114"]
+        + forcing["Effective Radiative Forcing|CFC115"]
+        + forcing["Effective Radiative Forcing|CCl4"]
+        + forcing["Effective Radiative Forcing|CH3CCl3"]
+        + forcing["Effective Radiative Forcing|HCFC22"]
+        + forcing["Effective Radiative Forcing|HCFC141b"]
+        + forcing["Effective Radiative Forcing|HCFC142b"]
+        + forcing["Effective Radiative Forcing|Halon1211"]
+        + forcing["Effective Radiative Forcing|Halon1202"]
+        + forcing["Effective Radiative Forcing|Halon1301"]
+        + forcing["Effective Radiative Forcing|Halon2402"]
+        + forcing["Effective Radiative Forcing|CH3Br"]
+        + forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing["Effective Radiative Forcing|Montreal Protocol Halogen Gases"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|Tropospheric Ozone"] +
-        forcing["Effective Radiative Forcing|Stratospheric Ozone"],
-        forcing["Effective Radiative Forcing|Ozone"]
+        forcing["Effective Radiative Forcing|Tropospheric Ozone"]
+        + forcing["Effective Radiative Forcing|Stratospheric Ozone"],
+        forcing["Effective Radiative Forcing|Ozone"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|SOx"] +
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol"] +
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate"] +
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|BC"] +
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|OC"],
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"]
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|SOx"]
+        + forcing[
+            "Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol"
+        ]
+        + forcing["Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate"]
+        + forcing["Effective Radiative Forcing|Aerosols|Direct Effect|BC"]
+        + forcing["Effective Radiative Forcing|Aerosols|Direct Effect|OC"],
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"],
     )
 
     # If up to here is fine, then we only need to check previouly defined aggregates against "super-aggregates"
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"] +
-        forcing["Effective Radiative Forcing|Aerosols|Indirect Effect"],
-        forcing["Effective Radiative Forcing|Aerosols"]
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"]
+        + forcing["Effective Radiative Forcing|Aerosols|Indirect Effect"],
+        forcing["Effective Radiative Forcing|Aerosols"],
     )
 
     npt.assert_allclose(
-        forcing["Effective Radiative Forcing|Greenhouse Gases"] +
-        forcing["Effective Radiative Forcing|Ozone"] + 
-        forcing["Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O"] +
-        forcing["Effective Radiative Forcing|Contrails"] +
-        forcing["Effective Radiative Forcing|Aerosols"] + 
-        forcing["Effective Radiative Forcing|Black Carbon on Snow"] +
-        forcing["Effective Radiative Forcing|Land-use Change"],
+        forcing["Effective Radiative Forcing|Greenhouse Gases"]
+        + forcing["Effective Radiative Forcing|Ozone"]
+        + forcing["Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O"]
+        + forcing["Effective Radiative Forcing|Contrails"]
+        + forcing["Effective Radiative Forcing|Aerosols"]
+        + forcing["Effective Radiative Forcing|Black Carbon on Snow"]
+        + forcing["Effective Radiative Forcing|Land-use Change"],
+        forcing["Effective Radiative Forcing|Anthropogenic"],
+    )
+
+    npt.assert_allclose(
         forcing["Effective Radiative Forcing|Anthropogenic"]
-    )
-
-    npt.assert_allclose(
-        forcing["Effective Radiative Forcing|Anthropogenic"] +
-        forcing["Effective Radiative Forcing|Volcanic"] +
-        forcing["Effective Radiative Forcing|Solar"],
-        forcing["Effective Radiative Forcing"]
+        + forcing["Effective Radiative Forcing|Volcanic"]
+        + forcing["Effective Radiative Forcing|Solar"],
+        forcing["Effective Radiative Forcing"],
     )

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -335,11 +335,7 @@ def test_forcing_categories(test_scenarios):
     ]
 
     res = run(
-        climate_models_cfgs={"FaIR":
-            [
-                {},
-            ],
-        },
+        climate_models_cfgs={"FaIR": [{}]},
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -323,7 +323,7 @@ def test_forcing_categories(test_scenarios):
             "Effective Radiative Forcing",
             "Effective Radiative Forcing|Anthropogenic",
             "Effective Radiative Forcing|Greenhouse Gases",
-            "Effective Radiative Forcing|Greenhouse Gases|Kyoto Gases",
+            "Effective Radiative Forcing|Kyoto Gases",
             "Effective Radiative Forcing|CO2, CH4 and N2O",
             "Effective Radiative Forcing|F-Gases",
             "Effective Radiative Forcing|Montreal Protocol Halogen Gases",
@@ -425,23 +425,7 @@ def test_forcing_categories(test_scenarios):
         forcing["Effective Radiative Forcing|HFC227ea"] +
         forcing["Effective Radiative Forcing|HFC245fa"] +
         forcing["Effective Radiative Forcing|HFC4310mee"] +
-        forcing["Effective Radiative Forcing|SF6"] +
-        forcing["Effective Radiative Forcing|CFC11"] +
-        forcing["Effective Radiative Forcing|CFC12"] +
-        forcing["Effective Radiative Forcing|CFC113"] +
-        forcing["Effective Radiative Forcing|CFC114"] +
-        forcing["Effective Radiative Forcing|CFC115"] +
-        forcing["Effective Radiative Forcing|CCl4"] +
-        forcing["Effective Radiative Forcing|CH3CCl3"] +
-        forcing["Effective Radiative Forcing|HCFC22"] +
-        forcing["Effective Radiative Forcing|HCFC141b"] +
-        forcing["Effective Radiative Forcing|HCFC142b"] +
-        forcing["Effective Radiative Forcing|Halon1211"] +
-        forcing["Effective Radiative Forcing|Halon1202"] +
-        forcing["Effective Radiative Forcing|Halon1301"] +
-        forcing["Effective Radiative Forcing|Halon2402"] +
-        forcing["Effective Radiative Forcing|CH3Br"] +
-        forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing["Effective Radiative Forcing|SF6"], 
         forcing["Effective Radiative Forcing|F-Gases"]
     )
 

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -335,7 +335,7 @@ def test_forcing_categories(test_scenarios):
     ]
 
     res = run(
-        climate_models_cfgs={"FaIR": [{}, ], },
+        climate_models_cfgs={"FaIR": [{},],},  # pylint: disable=E231
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -335,7 +335,11 @@ def test_forcing_categories(test_scenarios):
     ]
 
     res = run(
-        climate_models_cfgs={"FaIR": [{},],},  # pylint: disable=E231
+        climate_models_cfgs={"FaIR":
+            [
+                {},
+            ],
+        },
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -272,3 +272,235 @@ def test_startyear(test_scenarios, test_scenarios_2600):
             output_variables=("Surface Air Temperature Change",),
             out_config=None,
         )
+
+def test_forcing_categories(test_scenarios):
+    forcing_categories = [
+            "Effective Radiative Forcing|CO2",
+            "Effective Radiative Forcing|CH4",
+            "Effective Radiative Forcing|N2O",
+            "Effective Radiative Forcing|CF4",
+            "Effective Radiative Forcing|C2F6",
+            "Effective Radiative Forcing|C6F14",
+            "Effective Radiative Forcing|HFC23",
+            "Effective Radiative Forcing|HFC32",
+            "Effective Radiative Forcing|HFC125",
+            "Effective Radiative Forcing|HFC134a",
+            "Effective Radiative Forcing|HFC143a",
+            "Effective Radiative Forcing|HFC227ea",
+            "Effective Radiative Forcing|HFC245fa",
+            "Effective Radiative Forcing|HFC4310mee",
+            "Effective Radiative Forcing|SF6",
+            "Effective Radiative Forcing|CFC11",
+            "Effective Radiative Forcing|CFC12",
+            "Effective Radiative Forcing|CFC113",
+            "Effective Radiative Forcing|CFC114",
+            "Effective Radiative Forcing|CFC115",
+            "Effective Radiative Forcing|CCl4",
+            "Effective Radiative Forcing|CH3CCl3",
+            "Effective Radiative Forcing|HCFC22",
+            "Effective Radiative Forcing|HCFC141b",
+            "Effective Radiative Forcing|HCFC142b",
+            "Effective Radiative Forcing|Halon1211",
+            "Effective Radiative Forcing|Halon1202",
+            "Effective Radiative Forcing|Halon1301",
+            "Effective Radiative Forcing|Halon2402",
+            "Effective Radiative Forcing|CH3Br",
+            "Effective Radiative Forcing|CH3Cl",
+            "Effective Radiative Forcing|Tropospheric Ozone",
+            "Effective Radiative Forcing|Stratospheric Ozone",
+            "Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O",
+            "Effective Radiative Forcing|Contrails",
+            "Effective Radiative Forcing|Aerosols|Direct Effect|SOx",
+            "Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol",
+            "Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate",
+            "Effective Radiative Forcing|Aerosols|Direct Effect|BC",
+            "Effective Radiative Forcing|Aerosols|Direct Effect|OC",
+            "Effective Radiative Forcing|Aerosols|Indirect Effect",
+            "Effective Radiative Forcing|Black Carbon on Snow",
+            "Effective Radiative Forcing|Land-use Change",
+            "Effective Radiative Forcing|Volcanic",
+            "Effective Radiative Forcing|Solar",
+            "Effective Radiative Forcing",
+            "Effective Radiative Forcing|Anthropogenic",
+            "Effective Radiative Forcing|Greenhouse Gases",
+            "Effective Radiative Forcing|Greenhouse Gases|Kyoto Gases",
+            "Effective Radiative Forcing|CO2, CH4 and N2O",
+            "Effective Radiative Forcing|F-Gases",
+            "Effective Radiative Forcing|Montreal Protocol Halogen Gases",
+            "Effective Radiative Forcing|Aerosols|Direct Effect",
+            "Effective Radiative Forcing|Aerosols",
+            "Effective Radiative Forcing|Ozone",
+            "Effective Radiative Forcing",
+        ]
+
+    res = run(
+        climate_models_cfgs={
+            "FaIR": [
+                {},
+            ],
+        },
+        scenarios=test_scenarios.filter(scenario=["ssp245"]),
+        output_variables=tuple(forcing_categories),
+        out_config=None,
+    )
+
+    # storing results in a dict makes this a bit more compact
+    forcing = {}
+    for variable in forcing_categories:
+        forcing[variable] = res.filter(
+            variable=variable,
+            region="World"
+        ).values
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|CO2"] +
+        forcing["Effective Radiative Forcing|CH4"] +
+        forcing["Effective Radiative Forcing|N2O"] +
+        forcing["Effective Radiative Forcing|CF4"] +
+        forcing["Effective Radiative Forcing|C2F6"] +
+        forcing["Effective Radiative Forcing|C6F14"] +
+        forcing["Effective Radiative Forcing|HFC23"] +
+        forcing["Effective Radiative Forcing|HFC32"] +
+        forcing["Effective Radiative Forcing|HFC125"] +
+        forcing["Effective Radiative Forcing|HFC134a"] +
+        forcing["Effective Radiative Forcing|HFC143a"] +
+        forcing["Effective Radiative Forcing|HFC227ea"] +
+        forcing["Effective Radiative Forcing|HFC245fa"] +
+        forcing["Effective Radiative Forcing|HFC4310mee"] +
+        forcing["Effective Radiative Forcing|SF6"] +
+        forcing["Effective Radiative Forcing|CFC11"] +
+        forcing["Effective Radiative Forcing|CFC12"] +
+        forcing["Effective Radiative Forcing|CFC113"] +
+        forcing["Effective Radiative Forcing|CFC114"] +
+        forcing["Effective Radiative Forcing|CFC115"] +
+        forcing["Effective Radiative Forcing|CCl4"] +
+        forcing["Effective Radiative Forcing|CH3CCl3"] +
+        forcing["Effective Radiative Forcing|HCFC22"] +
+        forcing["Effective Radiative Forcing|HCFC141b"] +
+        forcing["Effective Radiative Forcing|HCFC142b"] +
+        forcing["Effective Radiative Forcing|Halon1211"] +
+        forcing["Effective Radiative Forcing|Halon1202"] +
+        forcing["Effective Radiative Forcing|Halon1301"] +
+        forcing["Effective Radiative Forcing|Halon2402"] +
+        forcing["Effective Radiative Forcing|CH3Br"] +
+        forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing["Effective Radiative Forcing|Greenhouse Gases"]  # should this be "well mixed" greenhouse gases?
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|CO2"] +
+        forcing["Effective Radiative Forcing|CH4"] +
+        forcing["Effective Radiative Forcing|N2O"] +
+        forcing["Effective Radiative Forcing|CF4"] +
+        forcing["Effective Radiative Forcing|C2F6"] +
+        forcing["Effective Radiative Forcing|C6F14"] +
+        forcing["Effective Radiative Forcing|HFC23"] +
+        forcing["Effective Radiative Forcing|HFC32"] +
+        forcing["Effective Radiative Forcing|HFC125"] +
+        forcing["Effective Radiative Forcing|HFC134a"] +
+        forcing["Effective Radiative Forcing|HFC143a"] +
+        forcing["Effective Radiative Forcing|HFC227ea"] +
+        forcing["Effective Radiative Forcing|HFC245fa"] +
+        forcing["Effective Radiative Forcing|HFC4310mee"] +
+        forcing["Effective Radiative Forcing|SF6"],
+        forcing["Effective Radiative Forcing|Kyoto Gases"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|CO2"] +
+        forcing["Effective Radiative Forcing|CH4"] +
+        forcing["Effective Radiative Forcing|N2O"],
+        forcing["Effective Radiative Forcing|CO2, CH4 and N2O"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|CF4"] +
+        forcing["Effective Radiative Forcing|C2F6"] +
+        forcing["Effective Radiative Forcing|C6F14"] +
+        forcing["Effective Radiative Forcing|HFC23"] +
+        forcing["Effective Radiative Forcing|HFC32"] +
+        forcing["Effective Radiative Forcing|HFC125"] +
+        forcing["Effective Radiative Forcing|HFC134a"] +
+        forcing["Effective Radiative Forcing|HFC143a"] +
+        forcing["Effective Radiative Forcing|HFC227ea"] +
+        forcing["Effective Radiative Forcing|HFC245fa"] +
+        forcing["Effective Radiative Forcing|HFC4310mee"] +
+        forcing["Effective Radiative Forcing|SF6"] +
+        forcing["Effective Radiative Forcing|CFC11"] +
+        forcing["Effective Radiative Forcing|CFC12"] +
+        forcing["Effective Radiative Forcing|CFC113"] +
+        forcing["Effective Radiative Forcing|CFC114"] +
+        forcing["Effective Radiative Forcing|CFC115"] +
+        forcing["Effective Radiative Forcing|CCl4"] +
+        forcing["Effective Radiative Forcing|CH3CCl3"] +
+        forcing["Effective Radiative Forcing|HCFC22"] +
+        forcing["Effective Radiative Forcing|HCFC141b"] +
+        forcing["Effective Radiative Forcing|HCFC142b"] +
+        forcing["Effective Radiative Forcing|Halon1211"] +
+        forcing["Effective Radiative Forcing|Halon1202"] +
+        forcing["Effective Radiative Forcing|Halon1301"] +
+        forcing["Effective Radiative Forcing|Halon2402"] +
+        forcing["Effective Radiative Forcing|CH3Br"] +
+        forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing["Effective Radiative Forcing|F-Gases"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|CFC11"] +
+        forcing["Effective Radiative Forcing|CFC12"] +
+        forcing["Effective Radiative Forcing|CFC113"] +
+        forcing["Effective Radiative Forcing|CFC114"] +
+        forcing["Effective Radiative Forcing|CFC115"] +
+        forcing["Effective Radiative Forcing|CCl4"] +
+        forcing["Effective Radiative Forcing|CH3CCl3"] +
+        forcing["Effective Radiative Forcing|HCFC22"] +
+        forcing["Effective Radiative Forcing|HCFC141b"] +
+        forcing["Effective Radiative Forcing|HCFC142b"] +
+        forcing["Effective Radiative Forcing|Halon1211"] +
+        forcing["Effective Radiative Forcing|Halon1202"] +
+        forcing["Effective Radiative Forcing|Halon1301"] +
+        forcing["Effective Radiative Forcing|Halon2402"] +
+        forcing["Effective Radiative Forcing|CH3Br"] +
+        forcing["Effective Radiative Forcing|CH3Cl"],
+        forcing["Effective Radiative Forcing|Montreal Protocol Halogen Gases"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|Tropospheric Ozone"] +
+        forcing["Effective Radiative Forcing|Stratospheric Ozone"],
+        forcing["Effective Radiative Forcing|Ozone"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|SOx"] +
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|Secondary Organic Aerosol"] +
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|Nitrate"] +
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|BC"] +
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect|OC"],
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"]
+    )
+
+    # If up to here is fine, then we only need to check previouly defined aggregates against "super-aggregates"
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|Aerosols|Direct Effect"] +
+        forcing["Effective Radiative Forcing|Aerosols|Indirect Effect"],
+        forcing["Effective Radiative Forcing|Aerosols"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|Greenhouse Gases"] +
+        forcing["Effective Radiative Forcing|Ozone"] + 
+        forcing["Effective Radiative Forcing|CH4 Oxidation Stratospheric H2O"] +
+        forcing["Effective Radiative Forcing|Contrails"] +
+        forcing["Effective Radiative Forcing|Aerosols"] + 
+        forcing["Effective Radiative Forcing|Black Carbon on Snow"] +
+        forcing["Effective Radiative Forcing|Land-use Change"],
+        forcing["Effective Radiative Forcing|Anthropogenic"]
+    )
+
+    npt.assert_allclose(
+        forcing["Effective Radiative Forcing|Anthropogenic"] +
+        forcing["Effective Radiative Forcing|Volcanic"] +
+        forcing["Effective Radiative Forcing|Solar"],
+        forcing["Effective Radiative Forcing"]
+    )

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -335,7 +335,7 @@ def test_forcing_categories(test_scenarios):
     ]
 
     res = run(
-        climate_models_cfgs={"FaIR": [{}, ], },
+        climate_models_cfgs={"FaIR": [{},],},
         scenarios=test_scenarios.filter(scenario=["ssp245"]),
         output_variables=tuple(forcing_categories),
         out_config=None,


### PR DESCRIPTION
Accidently set the wrong index for reporting anthropogenic total ERF from FaIR.

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
