### PR TITLE
Flexi progress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ master
 Changed
 ~~~~~~~
 
-- (`#41 <https://github.com/openscm/openscm-runner/pull/41>`_) Updated update frequency of :func:`run_magicc_parallel` to 5s
+- (`#41 <https://github.com/openscm/openscm-runner/pull/41>`_) Use consistent setting across all progress bars
 - (`#38 <https://github.com/openscm/openscm-runner/pull/38>`_) Updated scmdata requirements to handle change to openscm-units
 - (`#31 <https://github.com/openscm/openscm-runner/pull/31>`_) Unified key variable naming across MAGICC and FaIR
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ master
 Changed
 ~~~~~~~
 
+- (`#41 <https://github.com/openscm/openscm-runner/pull/41>`_) Updated update frequency of :func:`run_magicc_parallel` to 5s
 - (`#38 <https://github.com/openscm/openscm-runner/pull/38>`_) Updated scmdata requirements to handle change to openscm-units
 - (`#31 <https://github.com/openscm/openscm-runner/pull/31>`_) Unified key variable naming across MAGICC and FaIR
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 checks: $(VENV_DIR)  ## run all the checks
-	@echo "=== bandit ==="; $(VENV_DIR)/bin/bandit -c .bandit.yml -r openscm_runner || echo "--- bandit failed ---" >&2; \
+	@echo "=== bandit ==="; $(VENV_DIR)/bin/bandit -c .bandit.yml -r src || echo "--- bandit failed ---" >&2; \
 		echo "\n\n=== black ==="; $(VENV_DIR)/bin/black --check src tests setup.py docs/source/conf.py --exclude openscm_runner/_version.py || echo "--- black failed ---" >&2; \
 		echo "\n\n=== flake8 ==="; $(VENV_DIR)/bin/flake8 src tests setup.py || echo "--- flake8 failed ---" >&2; \
 		echo "\n\n=== isort ==="; $(VENV_DIR)/bin/isort --check-only --quiet src tests setup.py || echo "--- isort failed ---" >&2; \

--- a/notebooks/fair-gmst-ohu-factors.ipynb
+++ b/notebooks/fair-gmst-ohu-factors.ipynb
@@ -31,7 +31,7 @@
      "output_type": "stream",
      "text": [
       "pyam - INFO: Running in a notebook, setting `pyam` logging level to `logging.INFO` and adding stderr handler\n",
-      "/Users/znicholls/Documents/AGCEC/MCastle/openscm-runner/src/openscm_runner/run.py:7: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "/home/jared/code/uom/openscm-runner/src/openscm_runner/run.py:7: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  from tqdm.autonotebook import tqdm\n"
      ]
     }
@@ -50,7 +50,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.4.4+5.g9307ca0.dirty\n"
+      "0.4.4+48.gc9ac41f\n"
      ]
     }
    ],
@@ -72,7 +72,6 @@
     "import pandas as pd\n",
     "import pyam\n",
     "from fair.forward import fair_scm\n",
-    "from fair.tools.scmdf import scmdf_to_emissions\n",
     "from scmdata import ScmRun\n",
     "from tqdm import tqdm_notebook\n",
     "\n",
@@ -97,7 +96,7 @@
     {
      "data": {
       "text/plain": [
-       "'1.6.1'"
+       "'1.6.3'"
       ]
      },
      "execution_count": 5,
@@ -137,7 +136,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6049879f7c9e45eb8cf4a643af3e930c",
+       "model_id": "14c1ab6f99ea4c53ad3bfcba0e5b51f7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -151,7 +150,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "26d4eda6e84b4c29afb8a5c014149518",
+       "model_id": "e983fd439a5742b889fc4197f0dadca2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -204,7 +203,7 @@
     {
      "data": {
       "text/plain": [
-       "'FaIRv1.6.1'"
+       "'FaIRv1.6.3'"
       ]
      },
      "execution_count": 8,
@@ -232,7 +231,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x12f77f040>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f365e052310>"
       ]
      },
      "execution_count": 9,
@@ -273,7 +272,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x13092a040>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f365d53f450>"
       ]
      },
      "execution_count": 10,
@@ -314,7 +313,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x12ffdd400>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f365dfa1d90>"
       ]
      },
      "execution_count": 11,
@@ -364,7 +363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/src/openscm_runner/adapters/fair_adapter/fair_adapter.py
+++ b/src/openscm_runner/adapters/fair_adapter/fair_adapter.py
@@ -8,8 +8,8 @@ import fair
 import numpy as np
 import pandas as pd
 from scmdata import ScmRun
-from tqdm.autonotebook import tqdm
 
+from ...progress import progress
 from ..base import _Adapter
 from ._run_fair import run_fair
 from ._scmdf_to_emissions import scmdf_to_emissions
@@ -60,7 +60,7 @@ class FAIR(_Adapter):
         run_id_block = 0
         startyear = _check_startyear(cfgs)
 
-        for (scenario, model), smdf in tqdm(
+        for (scenario, model), smdf in progress(
             scenarios.timeseries().groupby(["scenario", "model"]),
             desc="Creating FaIR emissions inputs",
         ):

--- a/src/openscm_runner/adapters/magicc7/_parallel_process.py
+++ b/src/openscm_runner/adapters/magicc7/_parallel_process.py
@@ -158,6 +158,7 @@ def _parallel_process(  # pylint:disable=too-many-arguments
             config_are_kwargs=config_are_kwargs,
             desc="Front parallel",
             bar_start=front_serial,
+            mininterval=mininterval,
         )
 
     LOGGER.debug("Running rest of parallel jobs")

--- a/src/openscm_runner/adapters/magicc7/_parallel_process.py
+++ b/src/openscm_runner/adapters/magicc7/_parallel_process.py
@@ -29,7 +29,7 @@ def _run_serial(func, configs, config_are_kwargs, desc):
 
 
 def _run_parallel(  # pylint:disable=too-many-arguments
-    pool, timeout, func, configs, config_are_kwargs, desc, bar_start, mininterval
+    pool, timeout, func, configs, config_are_kwargs, desc, bar_start
 ):
     LOGGER.debug("Entering _run_parallel")
 

--- a/src/openscm_runner/adapters/magicc7/_parallel_process.py
+++ b/src/openscm_runner/adapters/magicc7/_parallel_process.py
@@ -25,7 +25,7 @@ def _run_serial(func, configs, config_are_kwargs, desc):
 
 
 def _run_parallel(  # pylint:disable=too-many-arguments
-    pool, timeout, func, configs, config_are_kwargs, desc, bar_start,
+    pool, timeout, func, configs, config_are_kwargs, desc, bar_start, mininterval
 ):
     LOGGER.debug("Entering _run_parallel")
 
@@ -41,6 +41,7 @@ def _run_parallel(  # pylint:disable=too-many-arguments
         "unit": "it",
         "unit_scale": True,
         "desc": desc,
+        "mininterval": mininterval,
     }
 
     LOGGER.debug("Waiting for jobs to complete")
@@ -80,6 +81,7 @@ def _parallel_process(  # pylint:disable=too-many-arguments
     front_serial=3,
     front_parallel=2,
     timeout=None,
+    mininterval=5,
 ):
     """
     Run a process in parallel with a progress bar.
@@ -114,6 +116,10 @@ def _parallel_process(  # pylint:disable=too-many-arguments
     timeout : float
         How long to wait for processes to complete before timing out. If
         ``None``, there is no timeout limit.
+
+    mininterval : int
+        Minimum interval between updating progress bar. Defaults to updating every
+        5s.
 
     Returns
     -------
@@ -163,6 +169,7 @@ def _parallel_process(  # pylint:disable=too-many-arguments
         config_are_kwargs=config_are_kwargs,
         desc="Parallel runs",
         bar_start=front_serial + front_parallel,
+        mininterval=mininterval,
     )
 
     return front_serial_res + front_parallel_res + rest

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -7,8 +7,8 @@ from subprocess import check_output  # nosec
 
 import pymagicc
 from scmdata import ScmRun, run_append
-from tqdm.autonotebook import tqdm
 
+from ...progress import progress
 from ...settings import config
 from ..base import _Adapter
 from ._run_magicc_parallel import run_magicc_parallel
@@ -139,7 +139,7 @@ class MAGICC7(_Adapter):
         full_cfgs = []
         run_id_block = 0
 
-        for (scenario, model), smdf in tqdm(
+        for (scenario, model), smdf in progress(
             scenarios.timeseries().groupby(["scenario", "model"]),
             desc="Writing SCEN7 files",
         ):

--- a/src/openscm_runner/progress.py
+++ b/src/openscm_runner/progress.py
@@ -30,6 +30,7 @@ def progress(*args, **kwargs):
     Returns
     -------
     tqdm.auto_notebook.tqdm
+        tqdm instance with consistent configuration
     """
     kwargs = {**_default_tqdm_params, **kwargs}
     return tqdm(*args, **kwargs)

--- a/src/openscm_runner/progress.py
+++ b/src/openscm_runner/progress.py
@@ -1,0 +1,32 @@
+from tqdm.autonotebook import tqdm
+
+
+# TODO: handle configuration in a consistent manner
+_default_tqdm_params = {
+    "mininterval": 5,
+    "unit": "it",
+    "unit_scale": True,
+}
+
+
+def progress(*args, **kwargs):
+    """
+    Wrapper around tqdm to provide consistent settings
+
+    Uses ``tqdm.autonotebook`` to automatically use a native Jupyter widget
+    when executing within a Jupyer Notebook.
+
+    Parameters
+    ----------
+    *args
+        Passed to the tqdm
+
+    **kwargs
+        Passed to the tqdm
+
+    Returns
+    -------
+    tqdm.auto_notebook.tqdm
+    """
+    kwargs = {**_default_tqdm_params, **kwargs}
+    return tqdm(*args, **kwargs)

--- a/src/openscm_runner/progress.py
+++ b/src/openscm_runner/progress.py
@@ -1,5 +1,8 @@
-from tqdm.autonotebook import tqdm
+"""
+Progress bar wrapper
+"""
 
+from tqdm.autonotebook import tqdm
 
 # TODO: handle configuration in a consistent manner
 _default_tqdm_params = {
@@ -11,7 +14,7 @@ _default_tqdm_params = {
 
 def progress(*args, **kwargs):
     """
-    Wrapper around tqdm to provide consistent settings
+    Progress bar
 
     Uses ``tqdm.autonotebook`` to automatically use a native Jupyter widget
     when executing within a Jupyer Notebook.

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -4,9 +4,10 @@ High-level run function
 import logging
 
 import scmdata
-from tqdm.autonotebook import tqdm
 
 from .adapters import FAIR, MAGICC7
+from ..progress import progress
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -71,7 +72,9 @@ def run(
     _check_out_config(out_config, climate_models_cfgs)
 
     res = []
-    for climate_model, cfgs in tqdm(climate_models_cfgs.items(), desc="Climate models"):
+    for climate_model, cfgs in progress(
+        climate_models_cfgs.items(), desc="Climate models"
+    ):
         if climate_model == "MAGICC7":
             runner = MAGICC7()
         elif climate_model.upper() == "FAIR":  # allow various capitalisations

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -6,7 +6,7 @@ import logging
 import scmdata
 
 from .adapters import FAIR, MAGICC7
-from ..progress import progress
+from .progress import progress
 
 
 LOGGER = logging.getLogger(__name__)

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -8,7 +8,6 @@ import scmdata
 from .adapters import FAIR, MAGICC7
 from .progress import progress
 
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -1,0 +1,26 @@
+from tqdm.autonotebook import tqdm
+from openscm_runner.progress import progress, _default_tqdm_params
+
+
+def test_progress(monkeypatch):
+    items = range(10)
+
+    iterable = progress(items)
+
+    assert isinstance(iterable, tqdm)
+    assert iterable.mininterval == 5
+    assert iterable.unit == "it"
+
+    monkeypatch.setitem(_default_tqdm_params, "mininterval", 2)
+
+    iterable = progress(items)
+    assert iterable.mininterval == 2
+
+
+def test_progress_disable(monkeypatch):
+    items = range(10)
+
+    monkeypatch.setitem(_default_tqdm_params, "disable", True)
+
+    iterable = progress(items)
+    assert iterable.disable

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -1,5 +1,6 @@
 from tqdm.autonotebook import tqdm
-from openscm_runner.progress import progress, _default_tqdm_params
+
+from openscm_runner.progress import _default_tqdm_params, progress
 
 
 def test_progress(monkeypatch):


### PR DESCRIPTION
Currently, the progress bar  for parallel magicc runs updates every time a run completes leading to a large number of superfluous log output.

I propose we reduce the update frequency of the progress bar to 5s from 0.1s. Is it worth propagating this to the user?

- [x] Tests added
- [x] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)

