### PR TITLE
Parallel FaIR

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,6 @@ MAGICC_WORKER_NUMBER=4
 # Where should the MAGICC workers be located on the filesystem (you need about
 # 500Mb space per worker at the moment)
 MAGICC_WORKER_ROOT_DIR=~/Desktop
+
+# How many cores should be used when running FaIR in parallel?
+FAIR_WORKER_NUMBER=4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ The changes listed in this file are categorised as follows:
 master
 ------
 
+Changed
+~~~~~~~
+
+- (`#43 <https://github.com/openscm/openscm-runner/pull/43>`_) Run FaIR in parallel
+
 v0.5.0 - 2021-02-24
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ master
 Changed
 ~~~~~~~
 
-- (`#43 <https://github.com/openscm/openscm-runner/pull/43>`_) Run FaIR in parallel
+- (`#43 <https://github.com/openscm/openscm-runner/pull/43>`_) Add ability to run FaIR in parallel
 
 v0.5.0 - 2021-02-24
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ SOURCE_DIR = "src"
 
 REQUIREMENTS = [
     "click",
-    "fair>=1.6.1,<2.0.0",
+    "fair==1.6.2",
     "matplotlib==3.2.2",
     "pyam-iamc",
     "pymagicc>=2.0.0rc9,<3",

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -32,10 +32,10 @@ def run_fair(cfgs, output_vars):  # pylint: disable=R0914
     """
     res = []
     updated_config = []
-    for i in range(len(cfgs)):
+    for i, cfg in enumerate(cfgs):
         updated_config.append({})
-        for key, value in cfgs[i].items():
-            if type(value) == list:
+        for key, value in cfg.items():
+            if isinstance(value, list):
                 updated_config[i][key] = np.asarray(value)
             else:
                 updated_config[i][key] = value
@@ -51,7 +51,7 @@ def run_fair(cfgs, output_vars):  # pylint: disable=R0914
     return res
 
 
-def _single_fair_iteration(cfg):
+def _single_fair_iteration(cfg):  # pylint: disable=R0914
     scenario = cfg.pop("scenario")
     model = cfg.pop("model")
     run_id = cfg.pop("run_id")

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -35,11 +35,11 @@ def run_fair(cfgs, output_vars):  # pylint: disable=R0914
     for i in range(len(cfgs)):
         updated_config.append({})
         for key, value in cfgs[i].items():
-            if type(value)==list:
+            if type(value) == list:
                 updated_config[i][key] = np.asarray(value)
             else:
                 updated_config[i][key] = value
-        updated_config[i]['output_vars'] = output_vars
+        updated_config[i]["output_vars"] = output_vars
 
     # this won't be appropriate in all cases - can we set an option for this?
     ncpu = multiprocessing.Pool(multiprocessing.cpu_count() - 1)
@@ -49,7 +49,6 @@ def run_fair(cfgs, output_vars):  # pylint: disable=R0914
     res = run_append(res)
 
     return res
-
 
 
 def _single_fair_iteration(cfg):
@@ -62,9 +61,7 @@ def _single_fair_iteration(cfg):
     startyear = cfg.pop("startyear")
     output_vars = cfg.pop("output_vars")
 
-    data, unit, nt = _process_output(
-        fair_scm(**cfg), output_vars, factors
-    )
+    data, unit, nt = _process_output(fair_scm(**cfg), output_vars, factors)
 
     data_scmrun = []
     variables = []

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -42,7 +42,7 @@ def run_fair(cfgs, output_vars):  # pylint: disable=R0914
         updated_config[i]["output_vars"] = output_vars
 
     # this won't be appropriate in all cases - can we set an option for this?
-    ncpu = multiprocessing.Pool(multiprocessing.cpu_count() - 1)
+    ncpu = multiprocessing.cpu_count() - 1
 
     with multiprocessing.Pool(ncpu) as pool:
         res = list(pool.imap(_single_fair_iteration, updated_config))

--- a/src/openscm_runner/adapters/fair_adapter/_run_fair.py
+++ b/src/openscm_runner/adapters/fair_adapter/_run_fair.py
@@ -11,7 +11,6 @@ from scmdata import ScmRun, run_append
 
 from ...settings import config
 
-
 LOGGER = logging.getLogger(__name__)
 toa_to_joule = 4 * np.pi * EARTH_RADIUS ** 2 * SECONDS_PER_YEAR
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -146,7 +146,9 @@ def run_magicc_parallel(cfgs, output_vars, output_config):
 
     try:
         pool = ProcessPoolExecutor(
-            max_workers=int(config.get("MAGICC_WORKER_NUMBER", multiprocessing.cpu_count())),
+            max_workers=int(
+                config.get("MAGICC_WORKER_NUMBER", multiprocessing.cpu_count())
+            ),
             initializer=_init_magicc_worker,
             initargs=(shared_dict,),
         )

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -146,7 +146,7 @@ def run_magicc_parallel(cfgs, output_vars, output_config):
 
     try:
         pool = ProcessPoolExecutor(
-            max_workers=int(config.get("MAGICC_WORKER_NUMBER", os.cpu_count())),
+            max_workers=int(config.get("MAGICC_WORKER_NUMBER", multiprocessing.cpu_count())),
             initializer=_init_magicc_worker,
             initargs=(shared_dict,),
         )

--- a/tests/integration/test_fair1X.py
+++ b/tests/integration/test_fair1X.py
@@ -10,7 +10,9 @@ from openscm_runner.utils import calculate_quantiles
 
 
 class TestFairAdapter(_AdapterTester):
-    def test_run(self, test_scenarios):
+    @pytest.mark.parametrize("nworkers", (1, 4))
+    def test_run(self, test_scenarios, monkeypatch, nworkers):
+        monkeypatch.setenv("FAIR_WORKER_NUMBER", "{}".format(nworkers))
         res = run(
             climate_models_cfgs={
                 "FaIR": [
@@ -212,7 +214,8 @@ def test_fair_ocean_factors(test_scenarios):
 
 
 def test_startyear(test_scenarios, test_scenarios_2600):
-    # we can't run different start years in the same ensemble as output files will differ in shape. There is a separate test to ensure this does raise an error.
+    # we can't run different start years in the same ensemble as output files will differ in shape.
+    # There is a separate test to ensure this does raise an error.
     res_1850 = run(
         climate_models_cfgs={"FaIR": [{"startyear": 1850}]},
         scenarios=test_scenarios.filter(scenario=["ssp245"]),


### PR DESCRIPTION
See #42 

- [x] Verify that this method is indeed faster
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)

A nice to have would be an option to allow the user to select the number of parallel processes. The default is set to the machine maximum minus 1 so that you can still check Facebook while this is running.