### PR TITLE
fair conda-install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ The changes listed in this file are categorised as follows:
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
 
+master
+------
+
 Changed
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ The changes listed in this file are categorised as follows:
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
 
+Changed
+~~~~~~~
+
+- (`#58 <https://github.com/openscm/openscm-runner/pull/58>`_) Update README for FaIR conda install
+
 v0.9.1 - 2021-09-23
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -83,9 +83,8 @@ To install all the requirements for FaIR, use the below
 
 .. code:: bash
 
-    conda install -c conda-forge openscm-runner pip
-    # FaIR is only available via pip
-    pip install fair
+    # FaIR
+    conda install -c conda-forge -c chrisroadmap openscm-runner fair
 
 .. sec-end-installation
 


### PR DESCRIPTION
FaIR can be installed from conda, which makes things a bit cleaner than using pip.

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
