### PR TITLE
Arbitrary adapters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ The changes listed in this file are categorised as follows:
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
 
+Unreleased
+----------
+
+Added
+~~~~~
+
+- (`#64 <https://github.com/openscm/openscm-runner/pull/64>`_) Allow for the registration of adapters at runtime. Adapters now require a unique ``model_name``
+
 v0.9.3 - 2022-01-19
 -------------------
 

--- a/src/openscm_runner/__init__.py
+++ b/src/openscm_runner/__init__.py
@@ -13,6 +13,6 @@ except ImportError:
 
 try:
     __version__ = _version("openscm_runner")
-except Exception:  # pylint: disable=broad-except pragma: no cover
+except Exception:  # pylint: disable=broad-except  # pragma: no cover
     # Local copy, not installed with setuptools
     __version__ = "unknown"

--- a/src/openscm_runner/__init__.py
+++ b/src/openscm_runner/__init__.py
@@ -13,6 +13,6 @@ except ImportError:
 
 try:
     __version__ = _version("openscm_runner")
-except Exception:  # pylint: disable=broad-except
+except Exception:  # pylint: disable=broad-except pragma: no cover
     # Local copy, not installed with setuptools
     __version__ = "unknown"

--- a/src/openscm_runner/adapters/__init__.py
+++ b/src/openscm_runner/adapters/__init__.py
@@ -4,8 +4,34 @@ Adapters for different climate models
 from .ciceroscm_adapter import CICEROSCM  # noqa: F401
 from .fair_adapter import FAIR  # noqa: F401
 from .magicc7 import MAGICC7  # noqa: F401
+from .base import _Adapter
 
 _registered_adapters = [CICEROSCM, FAIR, MAGICC7]
+
+
+def get_adapter(climate_model):
+    """
+    Get an adapter for a given climate_model
+
+    Parameters
+    ----------
+    climate_model: str
+        The name of the model to fetch
+
+        This parameter is case-insensitive
+
+    Returns
+    -------
+    openscm_runner.adapters.base._Adapter
+        The adapter for a given climate model
+    """
+    adapters_classes = get_adapters_classes()
+
+    for Adapter in adapters_classes:
+        if Adapter.model_name.upper() == climate_model.upper():
+            return Adapter()
+
+    raise NotImplementedError(f"No adapter available for {climate_model}")
 
 
 def get_adapters_classes():
@@ -14,6 +40,14 @@ def get_adapters_classes():
 
 def register_adapter_class(adapter_cls):
     existing_names = [a.model_name.upper() for a in _registered_adapters]
+
+    if not issubclass(adapter_cls, _Adapter):
+        raise ValueError(
+            "Adapter does not inherit from openscm_runner.adapters.base._Adapter"
+        )
+
+    if adapter_cls.model_name is None or not isinstance(adapter_cls.model_name, str):
+        raise ValueError("Cannot determine model_name")
 
     if any([adapter_cls.model_name.upper() == name for name in existing_names]):
         raise ValueError(

--- a/src/openscm_runner/adapters/__init__.py
+++ b/src/openscm_runner/adapters/__init__.py
@@ -3,10 +3,10 @@ Adapters for different climate models
 """
 from typing import List, Type
 
+from .base import _Adapter
 from .ciceroscm_adapter import CICEROSCM  # noqa: F401
 from .fair_adapter import FAIR  # noqa: F401
 from .magicc7 import MAGICC7  # noqa: F401
-from .base import _Adapter
 
 _registered_adapters: List[Type[_Adapter]] = [
     CICEROSCM,

--- a/src/openscm_runner/adapters/__init__.py
+++ b/src/openscm_runner/adapters/__init__.py
@@ -4,3 +4,20 @@ Adapters for different climate models
 from .ciceroscm_adapter import CICEROSCM  # noqa: F401
 from .fair_adapter import FAIR  # noqa: F401
 from .magicc7 import MAGICC7  # noqa: F401
+
+_registered_adapters = [CICEROSCM, FAIR, MAGICC7]
+
+
+def get_adapters_classes():
+    return _registered_adapters
+
+
+def register_adapter_class(adapter_cls):
+    existing_names = [a.model_name.upper() for a in _registered_adapters]
+
+    if any([adapter_cls.model_name.upper() == name for name in existing_names]):
+        raise ValueError(
+            "An adapter with the same model_name has already been registered"
+        )
+
+    _registered_adapters.append(adapter_cls)

--- a/src/openscm_runner/adapters/__init__.py
+++ b/src/openscm_runner/adapters/__init__.py
@@ -1,12 +1,18 @@
 """
 Adapters for different climate models
 """
+from typing import List, Type
+
 from .ciceroscm_adapter import CICEROSCM  # noqa: F401
 from .fair_adapter import FAIR  # noqa: F401
 from .magicc7 import MAGICC7  # noqa: F401
 from .base import _Adapter
 
-_registered_adapters = [CICEROSCM, FAIR, MAGICC7]
+_registered_adapters: List[Type[_Adapter]] = [
+    CICEROSCM,
+    FAIR,
+    MAGICC7,
+]
 
 
 def get_adapter(climate_model):
@@ -35,10 +41,34 @@ def get_adapter(climate_model):
 
 
 def get_adapters_classes():
+    """
+    Get a list of registered adapter classes
+
+    Returns
+    -------
+    list of Type[:class:`openscm_runner.adapters.base._Adapter`]
+    """
     return _registered_adapters
 
 
-def register_adapter_class(adapter_cls):
+def register_adapter_class(adapter_cls: Type[_Adapter]):
+    """
+    Register a new adapter class
+
+    Parameters
+    ----------
+    adapter_cls: Type[:class:`openscm_runner.adapters.base._Adapter`]
+        Adapter class to register
+
+        Must inherit from openscm_runner :class:`openscm_runner.adapters.base._Adapter` and have a unique `model_name`
+
+    Raises
+    ------
+    ValueError
+        `adapter_cls` does not inherit from :class:`openscm_runner.adapters.base._Adapter`
+
+        Invalid or non unique `model_name`
+    """
     existing_names = [a.model_name.upper() for a in _registered_adapters]
 
     if not issubclass(adapter_cls, _Adapter):

--- a/src/openscm_runner/adapters/__init__.py
+++ b/src/openscm_runner/adapters/__init__.py
@@ -26,6 +26,11 @@ def get_adapter(climate_model):
 
         This parameter is case-insensitive
 
+    Raises
+    ------
+    NotImplementedError
+        A matching adapter could not be found
+
     Returns
     -------
     openscm_runner.adapters.base._Adapter
@@ -79,7 +84,7 @@ def register_adapter_class(adapter_cls: Type[_Adapter]):
     if adapter_cls.model_name is None or not isinstance(adapter_cls.model_name, str):
         raise ValueError("Cannot determine model_name")
 
-    if any([adapter_cls.model_name.upper() == name for name in existing_names]):
+    if any(adapter_cls.model_name.upper() == name for name in existing_names):
         raise ValueError(
             "An adapter with the same model_name has already been registered"
         )

--- a/src/openscm_runner/adapters/base.py
+++ b/src/openscm_runner/adapters/base.py
@@ -9,6 +9,9 @@ class _Adapter(ABC):  # pylint: disable=too-few-public-methods
     Base class for adapters
     """
 
+    # Case-insensitive name of the simple climate model
+    model_name = None
+
     def __init__(self, *args, **kwargs):
         """
         Initialise the adapter

--- a/src/openscm_runner/adapters/ciceroscm_adapter/ciceroscm.py
+++ b/src/openscm_runner/adapters/ciceroscm_adapter/ciceroscm.py
@@ -16,6 +16,8 @@ class CICEROSCM(_Adapter):  # pylint: disable=too-few-public-methods
     Adapter for CICEROSCM
     """
 
+    model_name = "CiceroSCM"
+
     def __init__(self):  # pylint: disable=useless-super-delegation
         """
         Initialise the CICEROSCM adapter

--- a/src/openscm_runner/adapters/fair_adapter/fair_adapter.py
+++ b/src/openscm_runner/adapters/fair_adapter/fair_adapter.py
@@ -41,6 +41,8 @@ class FAIR(_Adapter):
     Adapter for running FAIR
     """
 
+    model_name = "FaIR"
+
     def _init_model(self, *args, **kwargs):
         if fair is None:
             raise ImportError("fair is not installed. Run 'pip install fair'")

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -50,6 +50,8 @@ class MAGICC7(_Adapter):
     emissions passed from the user are used.
     """
 
+    model_name = "MAGICC7"
+
     def __init__(self):
         """
         Initialise the MAGICC7 adapter

--- a/src/openscm_runner/adapters/utils/__init__.py
+++ b/src/openscm_runner/adapters/utils/__init__.py
@@ -1,29 +1,3 @@
 """
 Utility functions for adapters
 """
-from openscm_runner.adapters import get_adapters_classes
-
-
-def get_adapter(climate_model):
-    """
-    Get an adapter for a given climate_model
-
-    Parameters
-    ----------
-    climate_model: str
-        The name of the model to fetch
-
-        This parameter is case-insensitive
-
-    Returns
-    -------
-    openscm_runner.adapters.base._Adapter
-        The adapter for a given climate model
-    """
-    adapters_classes = get_adapters_classes()
-
-    for Adapter in adapters_classes:
-        if Adapter.model_name.upper() == climate_model.upper():
-            return Adapter()
-
-    raise NotImplementedError(f"No adapter available for {climate_model}")

--- a/src/openscm_runner/adapters/utils/__init__.py
+++ b/src/openscm_runner/adapters/utils/__init__.py
@@ -1,3 +1,29 @@
 """
 Utility functions for adapters
 """
+from openscm_runner.adapters import get_adapters_classes
+
+
+def get_adapter(climate_model):
+    """
+    Get an adapter for a given climate_model
+
+    Parameters
+    ----------
+    climate_model: str
+        The name of the model to fetch
+
+        This parameter is case-insensitive
+
+    Returns
+    -------
+    openscm_runner.adapters.base._Adapter
+        The adapter for a given climate model
+    """
+    adapters_classes = get_adapters_classes()
+
+    for Adapter in adapters_classes:
+        if Adapter.model_name.upper() == climate_model.upper():
+            return Adapter()
+
+    raise NotImplementedError(f"No adapter available for {climate_model}")

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -5,7 +5,7 @@ import logging
 
 import scmdata
 
-from .adapters.utils import get_adapter
+from .adapters import get_adapter
 from .progress import progress
 
 LOGGER = logging.getLogger(__name__)

--- a/src/openscm_runner/run.py
+++ b/src/openscm_runner/run.py
@@ -5,7 +5,7 @@ import logging
 
 import scmdata
 
-from .adapters import CICEROSCM, FAIR, MAGICC7
+from .adapters.utils import get_adapter
 from .progress import progress
 
 LOGGER = logging.getLogger(__name__)
@@ -74,14 +74,7 @@ def run(
     for climate_model, cfgs in progress(
         climate_models_cfgs.items(), desc="Climate models"
     ):
-        if climate_model == "MAGICC7":
-            runner = MAGICC7()
-        elif climate_model.upper() == "FAIR":  # allow various capitalisations
-            runner = FAIR()
-        elif climate_model.upper() == "CICEROSCM":  # allow various capitalisations
-            runner = CICEROSCM()
-        else:
-            raise NotImplementedError(f"No adapter available for {climate_model}")
+        runner = get_adapter(climate_model)
 
         if out_config is not None and climate_model in out_config:
             output_config_cm = out_config[climate_model]

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -1,0 +1,60 @@
+import pytest
+
+from openscm_runner.adapters import (
+    get_adapters_classes,
+    register_adapter_class,
+    _registered_adapters,
+)
+from openscm_runner.adapters.base import _Adapter
+
+
+class CustomAdapter(_Adapter):
+    model_name = "Custom"
+
+
+@pytest.fixture()
+def custom_adapters():
+    # Ensure that the adapter list is cleaned up after each test
+    existing_adapters = _registered_adapters.copy()
+
+    yield
+
+    _registered_adapters.clear()
+    _registered_adapters.extend(existing_adapters)
+
+
+def test_register_adapters(custom_adapters):
+    assert CustomAdapter not in get_adapters_classes()
+
+    register_adapter_class(CustomAdapter)
+
+    assert CustomAdapter in get_adapters_classes()
+
+
+# Doesn't inherit _Adapter
+class FakeAdapter:
+    model_name = "Custom"
+
+
+# model_name isn't defined
+class NoModelNameAdapter(_Adapter):
+    pass
+
+
+@pytest.mark.parametrize(
+    "cls,msg",
+    [
+        (
+            FakeAdapter,
+            "Adapter does not inherit from openscm_runner.adapters.base._Adapter",
+        ),
+        (NoModelNameAdapter, "Cannot determine model_name"),
+    ],
+)
+def test_register_adapters_invalid(custom_adapters, cls, msg):
+    assert cls not in get_adapters_classes()
+
+    with pytest.raises(ValueError, match=msg):
+        register_adapter_class(cls)
+
+    assert cls not in get_adapters_classes()

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -1,11 +1,11 @@
 import pytest
 
 from openscm_runner.adapters import (
+    MAGICC7,
+    _registered_adapters,
     get_adapter,
     get_adapters_classes,
     register_adapter_class,
-    MAGICC7,
-    _registered_adapters,
 )
 from openscm_runner.adapters.base import _Adapter
 

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -1,8 +1,10 @@
 import pytest
 
 from openscm_runner.adapters import (
+    get_adapter,
     get_adapters_classes,
     register_adapter_class,
+    MAGICC7,
     _registered_adapters,
 )
 from openscm_runner.adapters.base import _Adapter
@@ -10,6 +12,12 @@ from openscm_runner.adapters.base import _Adapter
 
 class CustomAdapter(_Adapter):
     model_name = "Custom"
+
+    def _init_model(self, *args, **kwargs):
+        pass
+
+    def _run(self, scenarios, cfgs, output_variables, output_config):
+        pass
 
 
 @pytest.fixture()
@@ -58,3 +66,21 @@ def test_register_adapters_invalid(custom_adapters, cls, msg):
         register_adapter_class(cls)
 
     assert cls not in get_adapters_classes()
+
+
+def test_registering_existing_adapter(custom_adapters):
+    msg = "An adapter with the same model_name has already been registered"
+    with pytest.raises(ValueError, match=msg):
+        register_adapter_class(MAGICC7)
+
+
+def test_get_adapter(custom_adapters):
+    msg = "No adapter available for custom"
+    with pytest.raises(NotImplementedError, match=msg):
+        get_adapter("custom")
+
+    register_adapter_class(CustomAdapter)
+
+    adapter = get_adapter("custom")
+
+    assert isinstance(adapter, CustomAdapter)


### PR DESCRIPTION
Refactor to how adapters are resolved to allow for arbitrary adapters to be registered. Each adapter now requires a `model_name` attribute which is used for getting the requested adapter.

- [x] Tests added
- [x] Documentation added
- [x] Example added (in the documentation, to an existing notebook, or in a new notebook) (in tests)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
