### PR TITLE
Log MAGICC7 errors more prominently

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ The changes listed in this file are categorised as follows:
     - Removed: now removed features
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
+Unreleased
+----------
+
+Changed
+~~~~~~~
+
+- (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
 
 Unreleased
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ The changes listed in this file are categorised as follows:
     - Removed: now removed features
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
+
 Unreleased
 ----------
 
@@ -20,13 +21,6 @@ Changed
 ~~~~~~~
 
 - (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
-
-Unreleased
-----------
-
-Changed
-~~~~~~~
-
 - (`#69 <https://github.com/openscm/openscm-runner/pull/69>`_) Updated dependency ``black`` to ``v22.3.0`` and pin ``isort`` and ``pylint`` for consistent pull requests
 
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -70,16 +70,15 @@ def _run_func(magicc, cfg):
             magicc_out_cfg = res.metadata["parameters"]["allcfgs"]
             for k in output_config:
                 res[k] = cfg[k]
-                if k in magicc_out_cfg:
-                    if magicc_out_cfg[k] != cfg[k]:
-                        LOGGER.warning(
-                            "Parameter: %s. "
-                            "MAGICC input config (via OpenSCM-Runner): %s. "
-                            "MAGICC output config: %s.",
-                            k,
-                            cfg[k],
-                            magicc_out_cfg[k],
-                        )
+                if k in magicc_out_cfg and magicc_out_cfg[k] != cfg[k]:
+                    LOGGER.warning(
+                        "Parameter: %s. "
+                        "MAGICC input config (via OpenSCM-Runner): %s. "
+                        "MAGICC output config: %s.",
+                        k,
+                        cfg[k],
+                        magicc_out_cfg[k],
+                    )
 
         return res
     except CalledProcessError as exc:

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -60,7 +60,7 @@ def _run_func(magicc, cfg):
 
         res = magicc.run(**cfg)
         if res.metadata["stderr"]:
-            LOGGER.info("magicc run stderr: %s", res.metadata["stderr"])
+            LOGGER.warning("magicc run stderr: %s", res.metadata["stderr"])
             LOGGER.info("cfg: %s", cfg)
 
         res["scenario"] = scenario

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -83,7 +83,7 @@ def _run_func(magicc, cfg):
         return res
     except CalledProcessError as exc:
         # Swallow the exception, but return None
-        LOGGER.debug("magicc run failed: %s", exc.stderr)
+        LOGGER.error("magicc run failed: %s", exc.stderr)
         LOGGER.debug("cfg: %s", cfg)
 
         return None


### PR DESCRIPTION
Use `LOGGER.warning` and `LOGGER.error` for MAGICC's logged errors and MAGICC's stderr for calling errors, respectively.

I didn't add tests, documentation or examples because it feels like none are applicable. I didn't add a changelog line because the changelog says it contains only *notable* changes, and I don't think this is particularly notable. If you disagree with any of that, I'll be happy to add any of those as well.

Regarding the existing tests: I only have MAGICC 7.5.3 at hand, and it seems the tests require MAGICC 7.5.1, at least I get failures if I just update the required version to 7.5.3. 

- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
