### PR TITLE
Automatically generate MAGICC worker root directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ The changes listed in this file are categorised as follows:
     - Removed: now removed features
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
+Unreleased
+----------
+
+Changed
+~~~~~~~
+
+- (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
 
 Unreleased
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,14 +22,6 @@ Changed
 
 - (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
 - (`#68 <https://github.com/openscm/openscm-runner/pull/68>`_) MAGICC7 adapter: automatically create a temporary directory when MAGICC_WORKER_ROOT_DIR is not specified.
-
-Unreleased
-----------
-
-Changed
-~~~~~~~
-
-- (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
 - (`#69 <https://github.com/openscm/openscm-runner/pull/69>`_) Updated dependency ``black`` to ``v22.3.0`` and pin ``isort`` and ``pylint`` for consistent pull requests
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ The changes listed in this file are categorised as follows:
     - Removed: now removed features
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
+
 Unreleased
 ----------
 
@@ -20,6 +21,7 @@ Changed
 ~~~~~~~
 
 - (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
+- (`#68 <https://github.com/openscm/openscm-runner/pull/68>`_) MAGICC7 adapter: automatically create a temporary directory when MAGICC_WORKER_ROOT_DIR is not specified.
 
 Unreleased
 ----------

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -42,4 +42,5 @@ MAGICC_WORKER_ROOT_DIR
 ++++++++++++++++++++++
 
 Where should the MAGICC workers be located on the filesystem (you need about
-500Mb space per worker at the moment)
+500Mb space per worker at the moment).
+If you don't specify the MAGICC_WORKER_ROOT_DIR, a temporary directory will automatically be created in Python's default location and will be deleted automatically as well.

--- a/src/openscm_runner/adapters/magicc7/_magicc_instances.py
+++ b/src/openscm_runner/adapters/magicc7/_magicc_instances.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 import shutil
 import tempfile
+import typing
 
 from ...settings import config
 from ._compat import pymagicc
@@ -56,7 +57,12 @@ class _MagiccInstances:
     def _generate_magicc_root(root_dir):
         return tempfile.mkdtemp(prefix="pymagicc-", dir=root_dir)
 
-    def get(self, root_dir=None, init_callback=None, init_callback_kwargs=None):
+    def get(
+        self,
+        root_dir: typing.Union[None, str] = None,
+        init_callback: typing.Union[None, typing.Callable] = None,
+        init_callback_kwargs: typing.Union[None, dict] = None,
+    ) -> pymagicc.MAGICC7:
         """
         Get a MAGICC object which is ready to run (always uses ``strict=False``)
 

--- a/src/openscm_runner/adapters/magicc7/_magicc_instances.py
+++ b/src/openscm_runner/adapters/magicc7/_magicc_instances.py
@@ -62,7 +62,7 @@ class _MagiccInstances:
         root_dir: typing.Union[None, str] = None,
         init_callback: typing.Union[None, typing.Callable] = None,
         init_callback_kwargs: typing.Union[None, dict] = None,
-    ) -> pymagicc.MAGICC7:
+    ) -> "pymagicc.MAGICC7":
         """
         Get a MAGICC object which is ready to run (always uses ``strict=False``)
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -226,12 +226,10 @@ def run_magicc_parallel(
             )
 
             LOGGER.info("Appending results into a single ScmRun")
-            res = scmdata.run_append([r for r in res if r is not None])
+            return scmdata.run_append([r for r in res if r is not None])
 
         finally:
             instances.cleanup()
             LOGGER.info("Shutting down parallel pool")
             shared_manager.shutdown()
             pool.shutdown()
-
-        return res

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -20,7 +20,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TemporaryDirectoryIfNeeded:
-    """A temporary directory context manager which works like
+    """
+    A temporary directory context manager which works like
     tempfile.TemporaryDirectory but supports existing directories.
 
     If instantiated without a directory, behaves exactly like
@@ -52,8 +53,11 @@ class TemporaryDirectoryIfNeeded:
             return repr(self._td)
 
     def cleanup(self):
-        """Delete the temporary directory if it was created. Does not delete
-        the directory if an existing directory was used."""
+        """
+        Delete the temporary directory if it was created.
+
+        Does not delete the directory if an existing directory was used.
+        """
         if self._td is not None:
             self._td.cleanup()
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -101,8 +101,8 @@ def _init_magicc_worker(dict_shared_instances):
 
 
 def _run_func(
-    magicc: "pymagicc.MAGICC7", cfg: dict[str, typing.Any]
-) -> typing.Union[None, dict[str, typing.Any]]:
+    magicc: "pymagicc.MAGICC7", cfg: typing.Dict[str, typing.Any]
+) -> typing.Union[None, typing.Dict[str, typing.Any]]:
     try:
         scenario = cfg.pop("scenario")
         model = cfg.pop("model")
@@ -140,10 +140,10 @@ def _run_func(
 
 
 def _execute_run(
-    cfg: dict[str, typing.Any],
+    cfg: typing.Dict[str, typing.Any],
     run_func: typing.Callable[
-        ["pymagicc.MAGICC7", dict[str, typing.Any]],
-        typing.Union[None, dict[str, typing.Any]],
+        ["pymagicc.MAGICC7", typing.Dict[str, typing.Any]],
+        typing.Union[None, typing.Dict[str, typing.Any]],
     ],
     setup_func: typing.Callable,
     instances: _MagiccInstances,
@@ -159,7 +159,7 @@ def _execute_run(
 
 
 def run_magicc_parallel(
-    cfgs: typing.Iterable[dict[str, typing.Any]],
+    cfgs: typing.Iterable[typing.Dict[str, typing.Any]],
     output_vars: typing.Iterable[str],
     output_config: typing.Iterable[str],
 ):

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -29,6 +29,7 @@ class TemporaryDirectoryIfNeeded:
     name, will use this directory instead and will *not* delete the directory
     when exiting the context.
     """
+
     def __init__(self, tempdir: typing.Union[None, str] = None, **kwargs):
         if tempdir is None:
             self._td = tempfile.TemporaryDirectory(**kwargs)
@@ -37,20 +38,21 @@ class TemporaryDirectoryIfNeeded:
             self._tempdir = tempdir
 
     def __enter__(self) -> str:
+        """Create temporary directory if needed."""
         if self._td is None:
             return self._tempdir
-        else:
-            return self._td.__enter__()
+        return self._td.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Delete directory if temporary directory was created."""
         if self._td is not None:
             self._td.__exit__(exc_type, exc_val, exc_tb)
 
     def __repr__(self):
+        """Human-readable representation."""
         if self._td is None:
             return f"<TemporaryDirectoryIfNeeded {self._tempdir}>"
-        else:
-            return repr(self._td)
+        return repr(self._td)
 
     def cleanup(self):
         """
@@ -189,7 +191,9 @@ def run_magicc_parallel(
         for v in output_vars
     ]
 
-    with TemporaryDirectoryIfNeeded(tempdir=config.get("MAGICC_WORKER_ROOT_DIR", None)) as root_dir:
+    with TemporaryDirectoryIfNeeded(
+        tempdir=config.get("MAGICC_WORKER_ROOT_DIR", None)
+    ) as root_dir:
         runs = [
             {
                 "cfg": {

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -101,7 +101,7 @@ def _init_magicc_worker(dict_shared_instances):
 
 
 def _run_func(
-    magicc: pymagicc.MAGICC7, cfg: dict[str, typing.Any]
+    magicc: "pymagicc.MAGICC7", cfg: dict[str, typing.Any]
 ) -> typing.Union[None, dict[str, typing.Any]]:
     try:
         scenario = cfg.pop("scenario")
@@ -142,7 +142,7 @@ def _run_func(
 def _execute_run(
     cfg: dict[str, typing.Any],
     run_func: typing.Callable[
-        [pymagicc.MAGICC7, dict[str, typing.Any]],
+        ["pymagicc.MAGICC7", dict[str, typing.Any]],
         typing.Union[None, dict[str, typing.Any]],
     ],
     setup_func: typing.Callable,

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -4,6 +4,7 @@ Module for running MAGICC in parallel
 import logging
 import multiprocessing
 import os.path
+import typing
 from concurrent.futures import ProcessPoolExecutor
 from subprocess import CalledProcessError  # nosec
 
@@ -52,7 +53,9 @@ def _init_magicc_worker(dict_shared_instances):
     )
 
 
-def _run_func(magicc, cfg):
+def _run_func(
+    magicc: pymagicc.MAGICC7, cfg: dict[str, typing.Any]
+) -> typing.Union[None, dict[str, typing.Any]]:
     try:
         scenario = cfg.pop("scenario")
         model = cfg.pop("model")
@@ -89,7 +92,15 @@ def _run_func(magicc, cfg):
         return None
 
 
-def _execute_run(cfg, run_func, setup_func, instances):
+def _execute_run(
+    cfg: dict[str, typing.Any],
+    run_func: typing.Callable[
+        [pymagicc.MAGICC7, dict[str, typing.Any]],
+        typing.Union[None, dict[str, typing.Any]],
+    ],
+    setup_func,
+    instances: _MagiccInstances,
+):
     magicc = instances.get(
         root_dir=config["MAGICC_WORKER_ROOT_DIR"],
         init_callback=setup_func,
@@ -99,7 +110,11 @@ def _execute_run(cfg, run_func, setup_func, instances):
     return run_func(magicc, cfg)
 
 
-def run_magicc_parallel(cfgs, output_vars, output_config):
+def run_magicc_parallel(
+    cfgs: typing.Iterable[dict[str, typing.Any]],
+    output_vars: typing.Iterable[str],
+    output_config: typing.Iterable[str],
+):
     """
     Run MAGICC in parallel using compact out files
 

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -32,6 +32,7 @@ class TemporaryDirectoryIfNeeded:
 
     def __init__(self, tempdir: typing.Union[None, str] = None, **kwargs):
         if tempdir is None:
+            # pylint: disable-next=consider-using-with
             self._td = tempfile.TemporaryDirectory(**kwargs)
         else:
             self._td = None

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -19,7 +19,7 @@ from ._magicc_instances import _MagiccInstances
 LOGGER = logging.getLogger(__name__)
 
 
-class TemporaryDirectory:
+class TemporaryDirectoryIfNeeded:
     """A temporary directory context manager which works like
     tempfile.TemporaryDirectory but supports existing directories.
 
@@ -47,11 +47,13 @@ class TemporaryDirectory:
 
     def __repr__(self):
         if self._td is None:
-            return f"<TemporaryDirectory {self._tempdir}>"
+            return f"<TemporaryDirectoryIfNeeded {self._tempdir}>"
         else:
             return repr(self._td)
 
     def cleanup(self):
+        """Delete the temporary directory if it was created. Does not delete
+        the directory if an existing directory was used."""
         if self._td is not None:
             self._td.cleanup()
 
@@ -183,7 +185,7 @@ def run_magicc_parallel(
         for v in output_vars
     ]
 
-    with TemporaryDirectory(tempdir=config.get("MAGICC_WORKER_ROOT_DIR", None)) as root_dir:
+    with TemporaryDirectoryIfNeeded(tempdir=config.get("MAGICC_WORKER_ROOT_DIR", None)) as root_dir:
         runs = [
             {
                 "cfg": {

--- a/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
+++ b/src/openscm_runner/adapters/magicc7/_run_magicc_parallel.py
@@ -43,7 +43,7 @@ class TemporaryDirectory:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._td is not None:
-            self.__exit__(exc_type, exc_val, exc_tb)
+            self._td.__exit__(exc_type, exc_val, exc_tb)
 
     def __repr__(self):
         if self._td is None:


### PR DESCRIPTION
Automatically generate MAGICC worker root directory as a temporary directory if MAGICC_WORKER_ROOT_DIR is not given. This is just a quality-of-life change to make it easier to "just run" magicc with as little boilerplate as possible.

I also did some light refactoring while understanding the code:
* added type hints to various functions
* reordered a try/finally block to make sure uninitialized variables aren't used in the `finally`block.

This PR is based on https://github.com/openscm/openscm-runner/pull/66 to avoid merge conflicts in `CHANGELOG.rst` down the line, so #66 should be merged before this one here.

- [ ] Tests added
- [x] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
