### PR TITLE
Add download from magicc.org to CI

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -67,7 +67,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Download MAGICC
+    - name: Download MAGICC non-windows
+      if: runner.os != 'Windows'
       run: |
         mkdir -p bin/magicc/magicc-v7.5.3
         wget -O "bin/magicc/magicc-v7.5.3.tar.gz" "${{ secrets.MAGICC_LINK_FROM_MAGICC_DOT_ORG }}"

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -67,12 +67,19 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Download MAGICC
+      run: |
+        mkdir -p bin/magicc/magicc-v7.5.3
+        wget -O "bin/magicc/magicc-v7.5.3.tar.gz" "${{ secrets.MAGICC_LINK_FROM_MAGICC_DOT_ORG }}"
+        tar -xf bin/magicc/magicc-v7.5.3.tar.gz -C bin/magicc/magicc-v7.5.3
     - name: Install test dependencies
       run: |
         pip install --upgrade pip wheel
         pip install -e .[tests,models]
     - name: Test with pytest non-windows
       if: runner.os != 'Windows'
+      env:
+        MAGICC_EXECUTABLE_7=bin/magicc/magicc-v7.5.3/bin/magicc
       run: |
           pytest tests -r a --cov=openscm_runner --cov-report='' --cov-fail-under=$MIN_COVERAGE
     - name: Test with pytest windows

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Test with pytest non-windows
       if: runner.os != 'Windows'
       env:
-        MAGICC_EXECUTABLE_7=bin/magicc/magicc-v7.5.3/bin/magicc
+        MAGICC_EXECUTABLE_7: bin/magicc/magicc-v7.5.3/bin/magicc
       run: |
           pytest tests -r a --cov=openscm_runner --cov-report='' --cov-fail-under=$MIN_COVERAGE
     - name: Test with pytest windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# binary files
+bin
+
 # vim swap files
 *.swp
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Unreleased
 Changed
 ~~~~~~~
 
+- (`#71 <https://github.com/openscm/openscm-runner/pull/71>`_) Run MAGICC as part of CI by using MAGICC binary downloaded from `magicc.org <https://magicc.org/download/magicc7>`_
 - (`#70 <https://github.com/openscm/openscm-runner/pull/70>`_) Updated the integration tests to use MAGICC v7.5.3 which is publicly available.
 - (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.
 - (`#68 <https://github.com/openscm/openscm-runner/pull/68>`_) MAGICC7 adapter: automatically create a temporary directory when MAGICC_WORKER_ROOT_DIR is not specified.


### PR DESCRIPTION
Add MAGICC tests to CI via binary downloaded from magicc.org

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
