### PR TITLE
Use environment for running CI

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -51,6 +51,7 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    environment: CI
     strategy:
       matrix:
         # no mac binary for CICERO so fails code coverage
@@ -96,6 +97,7 @@ jobs:
 
   test-notebooks:
     runs-on: ubuntu-latest
+    environment: CI
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Added
 Changed
 ~~~~~~~
 
+- (`#77 <https://github.com/openscm/openscm-runner/pull/77>`_) Use environment for running CI so forks can access secrets too
 - (`#71 <https://github.com/openscm/openscm-runner/pull/71>`_) Run MAGICC as part of CI by using MAGICC binary downloaded from `magicc.org <https://magicc.org/download/magicc7>`_
 - (`#70 <https://github.com/openscm/openscm-runner/pull/70>`_) Updated the integration tests to use MAGICC v7.5.3 which is publicly available.
 - (`#66 <https://github.com/openscm/openscm-runner/pull/66>`_) Log MAGICC7 errors more prominently.


### PR DESCRIPTION
Uses an environment for running CI in an attempt to allow forks to access secrets

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
