### PR TITLE
Use subdir of run directory 

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -68,6 +68,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download MAGICC non-windows
+      if: runner.os != 'Windows'
       run: |
         mkdir -p bin/magicc/magicc-v7.5.3
         wget -O "bin/magicc/magicc-v7.5.3.tar.gz" "${{ secrets.MAGICC_LINK_FROM_MAGICC_DOT_ORG }}"
@@ -95,8 +96,6 @@ jobs:
           pytest tests -r a
     - name: Test with pytest Windows
       if: runner.os == 'Windows'
-      env:
-        MAGICC_EXECUTABLE_7: bin/magicc/magicc-v7.5.3/bin/magicc.exe
       run: |
           pytest tests -r a --cov=openscm_runner --cov-report='' --cov-fail-under=$env:MIN_COVERAGE
 

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -68,7 +68,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download MAGICC non-windows
-      if: runner.os != 'Windows'
       run: |
         mkdir -p bin/magicc/magicc-v7.5.3
         wget -O "bin/magicc/magicc-v7.5.3.tar.gz" "${{ secrets.MAGICC_LINK_FROM_MAGICC_DOT_ORG }}"
@@ -96,6 +95,8 @@ jobs:
           pytest tests -r a
     - name: Test with pytest Windows
       if: runner.os == 'Windows'
+      env:
+        MAGICC_EXECUTABLE_7: bin/magicc/magicc-v7.5.3/bin/magicc.exe
       run: |
           pytest tests -r a --cov=openscm_runner --cov-report='' --cov-fail-under=$env:MIN_COVERAGE
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ The changes listed in this file are categorised as follows:
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
 
+Master
+------
+
+Changed
+~~~~~~~
+
+- (`#80 <https://github.com/openscm/openscm-runner/pull/80>`_) MAGICC adapter uses `run/openscm-runner` directory to store SCEN files instead of `run`
+
 v0.11.0 - 2022-08-18
 --------------------
 

--- a/src/openscm_runner/adapters/base.py
+++ b/src/openscm_runner/adapters/base.py
@@ -2,6 +2,7 @@
 Base class for adapters
 """
 from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, List
 
 
 class _Adapter(ABC):  # pylint: disable=too-few-public-methods
@@ -40,7 +41,13 @@ class _Adapter(ABC):  # pylint: disable=too-few-public-methods
             Keyword arguments used to initialise the model
         """
 
-    def run(self, scenarios, cfgs, output_variables, output_config):
+    def run(
+        self,
+        scenarios,
+        cfgs: List[Dict[str, Any]],
+        output_variables: Iterable[str],
+        output_config: Iterable[str],
+    ):
         """
         Parameters
         ----------
@@ -50,10 +57,10 @@ class _Adapter(ABC):  # pylint: disable=too-few-public-methods
         cfgs : list[dict]
             The config with which to run the model
 
-        output_variables : list[str]
+        output_variables : list of str or tuple of str
             Variables to include in the output
 
-        output_config : tuple[str]
+        output_config : list of str or tuple of str
             Configuration to include in the output
 
         Returns

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -224,4 +224,6 @@ class MAGICC7(_Adapter):
 
     @classmethod
     def _run_dir(cls):
-        return os.path.join(os.path.dirname(cls._executable()), "..", "run")
+        return os.path.abspath(
+            os.path.join(os.path.dirname(cls._executable()), "..", "run")
+        )

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -154,9 +154,13 @@ class MAGICC7(_Adapter):
 
         return out
 
-    def _write_scen_files_and_make_full_cfgs(self, scenarios, cfgs):
+    def _write_scen_files_and_make_full_cfgs(self, scenarios, cfgs, out_directory=None):
         full_cfgs = []
         run_id_block = 0
+
+        if out_directory is None:
+            out_directory = os.path.join(self._run_dir(), "openscm-runner")
+            os.makedirs(out_directory, exist_ok=True)
 
         for (scenario, model), smdf in progress(
             scenarios.timeseries().groupby(["scenario", "model"]),
@@ -174,7 +178,7 @@ class MAGICC7(_Adapter):
                 .replace(" ", "-")
             )
             writer.write(
-                os.path.join(self._run_dir(), scen_file_name),
+                os.path.join(out_directory, scen_file_name),
                 magicc_version=self.get_version()[1],
             )
 

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -159,6 +159,7 @@ class MAGICC7(_Adapter):
         run_id_block = 0
 
         if out_directory is None:
+            # Defaults to writing to the run/openscm-runner directory
             out_directory = os.path.join(self._run_dir(), "openscm-runner")
             os.makedirs(out_directory, exist_ok=True)
 

--- a/src/openscm_runner/adapters/magicc7/magicc7.py
+++ b/src/openscm_runner/adapters/magicc7/magicc7.py
@@ -177,8 +177,9 @@ class MAGICC7(_Adapter):
                 .replace("\\", "-")
                 .replace(" ", "-")
             )
+            scen_file_name = os.path.join(out_directory, scen_file_name)
             writer.write(
-                os.path.join(out_directory, scen_file_name),
+                scen_file_name,
                 magicc_version=self.get_version()[1],
             )
 

--- a/tests/integration/test_magicc7.py
+++ b/tests/integration/test_magicc7.py
@@ -113,6 +113,7 @@ class TestMagicc7Adapter(_AdapterTester):
             raise AssertionError(missing_vars)
 
 
+@pytest.mark.magicc
 def test_write_scen_files_and_make_full_cfgs(test_scenarios):
     adapter = MAGICC7()
     test_scenarios_magiccdf = pymagicc.io.MAGICCData(test_scenarios)

--- a/tests/integration/test_magicc7.py
+++ b/tests/integration/test_magicc7.py
@@ -136,7 +136,9 @@ def test_write_scen_files_and_make_full_cfgs(test_scenarios):
             .replace("\\", "-")
             .replace(" ", "-")
         )
-        scen_full_filename = os.path.join(adapter._run_dir(), "openscm-runner", scen_file_name)
+        scen_full_filename = os.path.join(
+            adapter._run_dir(), "openscm-runner", scen_file_name
+        )
 
         scenario_cfg = [v for v in res if v["file_emisscen"] == scen_full_filename]
 

--- a/tests/integration/test_magicc7.py
+++ b/tests/integration/test_magicc7.py
@@ -113,7 +113,6 @@ class TestMagicc7Adapter(_AdapterTester):
             raise AssertionError(missing_vars)
 
 
-@pytest.mark.magicc
 def test_write_scen_files_and_make_full_cfgs(test_scenarios):
     adapter = MAGICC7()
     test_scenarios_magiccdf = pymagicc.io.MAGICCData(test_scenarios)
@@ -137,8 +136,9 @@ def test_write_scen_files_and_make_full_cfgs(test_scenarios):
             .replace("\\", "-")
             .replace(" ", "-")
         )
+        scen_full_filename = os.path.join(adapter._run_dir(), "openscm-runner", scen_file_name)
 
-        scenario_cfg = [v for v in res if v["file_emisscen"] == scen_file_name]
+        scenario_cfg = [v for v in res if v["file_emisscen"] == scen_full_filename]
 
         assert len(scenario_cfg) == 1
         scenario_cfg = scenario_cfg[0]


### PR DESCRIPTION
This PR moves to using a subdirectory of the run_dir for housing the MAGICC SCEN files. This will enable that folder to be gitignored in the magicc repo.

The alternative was to write to a temp directory. I didn't see a way to automatically clean this up and it would hide the generated file.

- [x] Tests added
- [x] Documentation added
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/openscm/openscm-runner/pull/XX>`_) Added feature which does something``)
