### PR TITLE
Skip modern-adapter unit tests when fair2 / ciceroscm2 absent

### DIFF
--- a/tests/unit/adapters/test_ciceroscmpy2.py
+++ b/tests/unit/adapters/test_ciceroscmpy2.py
@@ -28,6 +28,22 @@ from unittest.mock import patch
 import pytest
 
 from openscm_runner.adapters import CICEROSCMPY2, get_adapter, get_adapters_classes
+from openscm_runner.adapters.ciceroscm_py2_adapter._compat import (
+    HAS_CICEROSCM_PY2,
+    _ciceroscm_major_version,
+)
+
+# Skip tests that instantiate CICEROSCMPY2() (which calls _init_model
+# and imports / version-checks the underlying ciceroscm package) when
+# ciceroscm>=2 isn't available. CI installs `--all-extras` but pip can
+# only have one major version of `ciceroscm` at a time; when the
+# lockfile resolved to ciceroscm 1.x, _ciceroscm_major_version returns
+# 1 and these tests skip cleanly instead of raising the documented
+# ImportError.
+cicero_skip = pytest.mark.skipif(
+    not HAS_CICEROSCM_PY2 or _ciceroscm_major_version() < 2,
+    reason="ciceroscm>=2 not installed",
+)
 
 
 # Required sidecar keys after the Phase F rewrite. Tests parametrised
@@ -60,6 +76,7 @@ def _make_full_cfg(tmp_path) -> dict:
 # ---------------------------------------------------------------------------
 
 
+@cicero_skip
 def test_ciceroscmpy2_is_registered():
     assert CICEROSCMPY2.model_name == "CICERO-SCM-PY2"
     assert CICEROSCMPY2 in get_adapters_classes()
@@ -92,6 +109,7 @@ def test_ciceroscmpy2_raises_when_wrong_major_version():
 # ---------------------------------------------------------------------------
 
 
+@cicero_skip
 def test_ciceroscmpy2_run_rejects_output_config(tmp_path):
     adapter = CICEROSCMPY2()
     with pytest.raises(NotImplementedError, match="output_config"):
@@ -103,6 +121,7 @@ def test_ciceroscmpy2_run_rejects_output_config(tmp_path):
         )
 
 
+@cicero_skip
 @pytest.mark.parametrize("missing_key", _REQUIRED_CFG_KEYS)
 def test_ciceroscmpy2_rejects_cfg_missing_required_sidecar(
     tmp_path, missing_key,
@@ -126,6 +145,7 @@ def test_ciceroscmpy2_rejects_cfg_missing_required_sidecar(
         )
 
 
+@cicero_skip
 def test_ciceroscmpy2_rejects_missing_distribution_json(tmp_path):
     """
     After sidecar-key validation, the path is checked for existence
@@ -145,6 +165,7 @@ def test_ciceroscmpy2_rejects_missing_distribution_json(tmp_path):
         )
 
 
+@cicero_skip
 def test_ciceroscmpy2_rejects_empty_member_indices(tmp_path):
     """
     An explicit empty member_indices is almost certainly a user
@@ -188,6 +209,7 @@ def _populate_minimal_calibration_dir(cal_dir) -> None:
     (cal_dir / "draw_samples_500.json").write_text("")
 
 
+@cicero_skip
 def test_from_native_distribution_resolves_canonical_files(tmp_path):
     """
     Given a calibration directory with canonical filenames, the
@@ -243,6 +265,7 @@ def test_from_native_distribution_errors_when_path_missing(tmp_path):
         CICEROSCMPY2.from_native_distribution(missing)
 
 
+@cicero_skip
 def test_from_native_distribution_explicit_distribution_json_overrides_default(
     tmp_path,
 ):
@@ -262,6 +285,7 @@ def test_from_native_distribution_explicit_distribution_json_overrides_default(
     assert adapter.cfgs[0]["distribution_json"] == str(other_dist)
 
 
+@cicero_skip
 def test_from_native_distribution_cfg_overrides_take_precedence(tmp_path):
     """
     Keyword arguments to ``from_native_distribution`` become cfg keys
@@ -279,6 +303,7 @@ def test_from_native_distribution_cfg_overrides_take_precedence(tmp_path):
     assert adapter.cfgs[0]["gaspam_file"] == str(custom_gaspam)
 
 
+@cicero_skip
 def test_from_native_distribution_override_skips_missing_canonical_file(tmp_path):
     """
     Partial override: when the user supplies a cfg-level override for

--- a/tests/unit/adapters/test_fair2.py
+++ b/tests/unit/adapters/test_fair2.py
@@ -25,11 +25,22 @@ from unittest.mock import patch
 import pytest
 
 from openscm_runner.adapters import FAIR2, get_adapter, get_adapters_classes
+from openscm_runner.adapters.fair2_adapter._compat import HAS_FAIR2
 from openscm_runner.adapters.fair2_adapter._native_calibration import (
     NativeFairCalibration,
 )
 
+# Skip tests that instantiate FAIR2() (which calls _init_model and imports
+# the underlying fair package) when fair>=2 isn't available. CI installs
+# `--all-extras` but pip can only have one major version of `fair` at a
+# time; when the lockfile resolved to fair 1.6.x, HAS_FAIR2 is False and
+# these tests skip cleanly instead of raising the documented ImportError.
+fair2_skip = pytest.mark.skipif(
+    not HAS_FAIR2, reason="fair>=2 not installed"
+)
 
+
+@fair2_skip
 def test_fair2_is_registered():
     assert FAIR2.model_name == "FaIRv2"
     assert FAIR2 in get_adapters_classes()
@@ -129,6 +140,7 @@ def test_native_calibration_file_returns_none_for_absent_optional(tmp_path):
     assert cal.file("species_configs") is not None
 
 
+@fair2_skip
 def test_fair2_translated_cfg_with_no_climate_configs_raises_useful_error():
     """
     Translated-cfg mode runs without a calibration bundle. If the cfg
@@ -146,6 +158,7 @@ def test_fair2_translated_cfg_with_no_climate_configs_raises_useful_error():
         )
 
 
+@fair2_skip
 def test_fair2_run_rejects_mixed_native_and_translated_cfgs():
     """
     Each cfg list must be entirely native or entirely translated;
@@ -164,6 +177,7 @@ def test_fair2_run_rejects_mixed_native_and_translated_cfgs():
         )
 
 
+@fair2_skip
 def test_fair2_run_rejects_output_config():
     adapter = FAIR2()
     with pytest.raises(NotImplementedError, match="output_config"):
@@ -175,6 +189,7 @@ def test_fair2_run_rejects_output_config():
         )
 
 
+@fair2_skip
 def test_fair2_translated_cfg_warns_on_unknown_parameter_names(caplog):
     """
     Translated-cfg mode logs a WARNING when a cfg dict carries keys
@@ -240,6 +255,7 @@ def test_fair2_stochastic_run_default_is_off():
     )
 
 
+@fair2_skip
 def test_fair2_conc_driven_requires_a_conc_source(tmp_path):
     """
     Concentration-driven mode needs concentrations from somewhere:


### PR DESCRIPTION
Picks up the unit-test failures on #97. When CI installs
`--all-extras`, pip can only resolve one major version of the
underlying `fair` and `ciceroscm` packages at a time (the `[fair]` +
`[fair2]` extras pin incompatible majors; same for `[ciceroscmpy]` +
`[ciceroscmpy2]`). When the lockfile resolves to the legacy major
(fair 1.6.x / ciceroscm 1.x), instantiating `FAIR2()` or
`CICEROSCMPY2()` hits a documented `ImportError` from the
`_init_model` shim, which was bubbling up as unit-test failures on
#97 across the matrix.

Adds `fair2_skip` and `cicero_skip` markers (mirroring the existing
ones in `tests/integration/test_modern_adapters.py`) to every unit
test that constructs the modern adapter or calls
`from_native_distribution(...)` (which calls the constructor at the
end). Tests that patch `HAS_FAIR2` / `HAS_CICEROSCM_PY2` to test the
import-error path stay unmarked (they specifically exercise the
"package missing" surface). Tests that touch only standalone helpers
(`NativeFairCalibration`, `_resolve_protocol_flags` /
`_resolve_protocol_spec`, emissions / concentrations translators)
also stay unmarked.

Locally (venv has `fair>=2` + `ciceroscm>=2`): 46/46 tests still run
and pass. Under #97's legacy lockfile resolution, the skip markers
fire and the failing unit-test count drops to 0.

The underlying mutual-exclusion problem between `[fair]` /
`[fair2]` and `[ciceroscmpy]` / `[ciceroscmpy2]` is real but
separate; worth a follow-up discussion about deprecating the legacy
adapters once the modern ones land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)